### PR TITLE
Update to Debian 13.0 and bump addon version to 2.5.0

### DIFF
--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0
+
+Update base from Debian 12.10 to Debian 13.0
+
 ## 2.4.0
 
 Update base from Debian 12.9 to Debian 12.10

--- a/boinc/Dockerfile
+++ b/boinc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM="amd64/debian:12.10-slim"
+ARG BUILD_FROM="amd64/debian:13.0-slim"
 
 # hadolint ignore=DL3006
 FROM $BUILD_FROM

--- a/boinc/build.yaml
+++ b/boinc/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: arm64v8/debian:12.10-slim
-  amd64: amd64/debian:12.10-slim
-  armhf: arm32v5/debian:12.10-slim
-  armv7: arm32v7/debian:12.10-slim
-  i386: i386/debian:12.10-slim
+  aarch64: arm64v8/debian:13.0-slim
+  amd64: amd64/debian:13.0-slim
+  armhf: arm32v5/debian:13.0-slim
+  armv7: arm32v7/debian:13.0-slim
+  i386: i386/debian:13.0-slim
 labels:
   org.opencontainers.image.title: "Boinc add-on"
   org.opencontainers.image.description: "Home Assistant Boinc add-on."

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,5 +1,5 @@
 name: Boinc
-version: "2.4.0"
+version: "2.5.0"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"


### PR DESCRIPTION
- Updated base images from Debian 12.10 to Debian 13.0 for all architectures
- Bumped addon version from 2.4.0 to 2.5.0
- Updated CHANGELOG.md with version 2.5.0 changes
- Applied changes to Dockerfile, build.yaml, and config.yaml