### PR TITLE
chore: update base image to Debian 13.6

### DIFF
--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.0
+
+Update base from Debian 13.5 to Debian 13.6
+
 ## 3.6.3
 
 Maintenance update with minor improvements

--- a/boinc/Dockerfile
+++ b/boinc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM="debian:13.5-slim"
+ARG BUILD_FROM="debian:13.6-slim"
 
 # hadolint ignore=DL3006
 FROM $BUILD_FROM

--- a/boinc/build.yaml
+++ b/boinc/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: debian:13.5-slim
-  amd64: debian:13.5-slim
+  aarch64: debian:13.6-slim
+  amd64: debian:13.6-slim
 labels:
   org.opencontainers.image.title: "Boinc add-on"
   org.opencontainers.image.description: "Home Assistant Boinc add-on."

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC
-version: "3.6.3"
+version: "3.7.0"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"

--- a/boinctui/CHANGELOG.md
+++ b/boinctui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.0
+
+Update base from Debian 13.5 to Debian 13.6
+
 ## 2.3.4
 
 Maintenance update with minor improvements

--- a/boinctui/Dockerfile
+++ b/boinctui/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM="debian:13.5-slim"
+ARG BUILD_FROM="debian:13.6-slim"
 
 # hadolint ignore=DL3006
 FROM $BUILD_FROM

--- a/boinctui/build.yaml
+++ b/boinctui/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: debian:13.5-slim
-  amd64: debian:13.5-slim
+  aarch64: debian:13.6-slim
+  amd64: debian:13.6-slim
 labels:
   org.opencontainers.image.title: "boinctui add-on"
   org.opencontainers.image.description: "Home Assistant boinctui add-on."

--- a/boinctui/config.yaml
+++ b/boinctui/config.yaml
@@ -1,5 +1,5 @@
 name: boinctui
-version: "2.3.4"
+version: "2.4.0"
 slug: boinctui
 description: Fullscreen text mode manager for BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinctui"


### PR DESCRIPTION
## Summary
- Bump both add-ons' base image from `debian:13.5-slim` to `debian:13.6-slim` (Dockerfile `ARG BUILD_FROM` + `build.yaml` per-arch `build_from`)
- Version bump: `boinc` 3.6.3 → 3.7.0, `boinctui` 2.3.4 → 2.4.0
- `CHANGELOG.md` entries added for both

## Test plan
- [x] `docker build` succeeds for both `boinc/` and `boinctui/` against the new base
- [x] `boinc`: CI-style smoke test (`--exit-immediately true`) exits 0; persistent run + `docker exec boinccmd --get_state` returns a valid client state
- [x] `boinctui`: container starts and `ttyd` serves the terminal UI (HTTP 200) on port 7681
- [x] Verified via the `run-boinc-addons` skill driver (`.claude/skills/run-boinc-addons/smoke.sh all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP