### PR TITLE
fix(boinc): the five highest-impact operator bugs

### DIFF
--- a/.claude/skills/run-boinc-addons/SKILL.md
+++ b/.claude/skills/run-boinc-addons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-boinc-addons
-description: Build, run, and smoke-test the boinc and boinctui Home Assistant add-ons via plain Docker (no Supervisor needed). Use when asked to run boinc-addons, build/start the boinc or boinctui add-on, start the BOINC client in a container, talk to it via boinccmd, test the boinctui ttyd terminal UI, or run the operator's Python unit tests.
+description: Build, run, and smoke-test the boinc and boinctui Home Assistant add-ons, either via plain Docker or under a real Home Assistant Supervisor. Use when asked to run boinc-addons, build/start the boinc or boinctui add-on, start the BOINC client in a container, talk to it via boinccmd, test the boinctui ttyd terminal UI, test an add-on in Home Assistant/Supervisor/the devcontainer, or run the operator's Python unit tests.
 ---
 
 This repo ships two independent Home Assistant add-ons (`boinc/`, `boinctui/`), each
@@ -10,6 +10,12 @@ just a Dockerfile — no Supervisor is needed to build/run/drive them locally, p
 and verifies it's actually working (`boinccmd` RPC for `boinc`, an HTTP request to
 `ttyd` for `boinctui`), then tears everything down. All paths below are relative to
 the repo root.
+
+Plain Docker cannot see anything Supervisor does *around* the container: option
+schema validation, `config.yaml`/`build.yaml` conformance, translations, ingress,
+protection mode, watchdog. For those, use `supervisor.sh` (see "Run under a real
+Supervisor" below) — it is slower and heavier, so reach for `smoke.sh` first and
+escalate only when the question is about the add-on's Home Assistant surface.
 
 ## Prerequisites
 
@@ -62,6 +68,55 @@ request (no ingress header) gets a `407 Proxy Auth Required` from `ttyd`. This i
 only reachable through Home Assistant's Ingress in production, which injects the
 required header automatically.
 
+## Run under a real Supervisor
+
+Use this when the question is about the add-on's Home Assistant surface rather than
+its process: whether `config.yaml`/`build.yaml` are accepted, whether the option
+schema and `translations/*.yaml` render, whether ingress is wired, whether
+protection mode/watchdog behave. It boots the repo's `.devcontainer`
+(`ghcr.io/home-assistant/devcontainer:2-addons`) with a full Supervisor stack
+(`hassio_supervisor`, `cli`, `dns`, `audio`, `observer`, `multicast`,
+`homeassistant`) and installs the add-on from the local store, building it from
+your working tree.
+
+```bash
+./.claude/skills/run-boinc-addons/supervisor.sh up               # boot Supervisor (idempotent)
+./.claude/skills/run-boinc-addons/supervisor.sh install boinc    # stage + build + install + start
+./.claude/skills/run-boinc-addons/supervisor.sh install boinctui
+./.claude/skills/run-boinc-addons/supervisor.sh logs boinc       # the log as Supervisor sees it
+./.claude/skills/run-boinc-addons/supervisor.sh status
+./.claude/skills/run-boinc-addons/supervisor.sh down             # remove container + volumes (~5GB)
+```
+
+`install` prints the installed state, e.g.:
+
+```
+{"slug": "local_boinctui", "version": "2.4.1", "state": "started", "protected": true}
+```
+
+Cost: ~2GB of HA images on the first `up` (several minutes), plus a full add-on
+build per `install`. Everything lives inside the `ha-addons-dev` container and two
+named volumes; the repo is only ever read.
+
+Home Assistant's own UI is at `http://localhost:7123` once Core finishes starting,
+but you do not need it — add-ons install and run through Supervisor alone, which is
+why `up` waits on the Supervisor API rather than the UI.
+
+Useful probes once an add-on is installed (all through the CLI in `hassio_cli`):
+
+```bash
+docker exec ha-addons-dev bash -lc \
+  'docker exec hassio_cli ha apps info local_boinctui --raw-json' | jq -c '.data.ingress_url'
+# -> "/api/hassio_ingress/t8TZXaXBaLxQ9i9GCxhdl4e7yzqk0wrkOwIr3a3hsks/"
+
+docker exec ha-addons-dev bash -lc \
+  'docker exec hassio_cli ha apps info local_boinc --raw-json' | jq '.data.translations.es.configuration | length'
+# -> 10
+
+docker exec ha-addons-dev bash -lc 'docker logs hassio_supervisor 2>&1 | grep -i "apps.validate\|apps.build"'
+# config.yaml / build.yaml conformance warnings for your add-on land here
+```
+
 ## Test
 
 Operator unit tests (from `boinc/operator/`) need the `dict2xml` package, which
@@ -100,6 +155,30 @@ Gotchas.
   (`curl: (56) Recv failure: Connection reset by peer`) before it's actually
   listening — the driver retries with a short poll loop, so this only matters if
   you're curling it manually; retry once or two after a `sleep 0.5`.
+- **Supervisor mode, five traps, all handled by `supervisor.sh` — but you will hit
+  them the moment you drive it by hand:**
+  1. `supervisor_run` calls `stty sane` and runs under `set -e`, so without a TTY it
+     dies silently right after `Waiting for Docker to initialize...`. Use
+     `docker exec -dt`, never `-d` alone.
+  2. In docker-in-docker the `docker_gateway_unprotected` health check fails and
+     Supervisor refuses every install with `blocked from execution, system is not
+     healthy`. Clear it with `ha jobs options --ignore-conditions healthy`.
+  3. `devcontainer_bootstrap` bind-mounts the workspace into
+     `/mnt/supervisor/addons/local/`, but the current Supervisor reads its local
+     store from `/mnt/supervisor/apps/local/` (the add-on -> app rename). Stage
+     add-ons in `apps/local` or Supervisor silently uses the stale copy.
+  4. With `image:` present in `config.yaml`, Supervisor pulls the published image
+     instead of building your working tree — and 404s if that version isn't
+     released. Comment it out in the staged copy (the driver does).
+  5. Restarting `hassio_supervisor` by hand loses `/run/supervisor`, after which
+     Home Assistant Core fails to start with `bind source path does not exist`.
+     `mkdir -p /run/supervisor` before rebooting Supervisor fixes it.
+- **An installed add-on's metadata is a snapshot.** Supervisor stores the parsed
+  `config.yaml`/`translations` in `/mnt/supervisor/apps.json` at install time, so
+  `ha apps info` keeps serving the old values after you edit those files — even
+  across a Supervisor restart. Re-run `install` to re-read them.
+- **`ha apps logs local_boinctui` is legitimately empty** until something connects
+  through ingress: `ttyd` writes nothing on startup. `local_boinc` logs immediately.
 - **Operator unit tests silently under-report** if `dict2xml` isn't installed:
   `python -m unittest discover` still exits with a failure summary, but only 2 of
   the 5 test modules actually failed to import — read the `ModuleNotFoundError`,
@@ -117,3 +196,13 @@ Gotchas.
   `--workdir /data/boinc` on the `docker exec` call — see Gotchas.
 - **`curl` on boinctui's port → `407 Proxy Auth Required`**: missing the
   `X-Remote-User-Name` header — see Gotchas.
+- **Supervisor install fails with `Can't install ghcr.io/...:<version>: [404]
+  manifest unknown`**: it is pulling instead of building. Either `image:` is still
+  uncommented in the staged copy, or Supervisor is reading a stale copy from
+  `apps/local` — see Gotchas 3 and 4.
+- **Supervisor build fails with `/bin/bash: line 1: apt-get: command not found`**:
+  `build.yaml` was rejected and Supervisor fell back to its Alpine base. Check for
+  `Error parsing ... build config ... using defaults` in the Supervisor log; the
+  cause is a `build_from` value that doesn't match Supervisor's `owner/name` regex,
+  which is why both add-ons pin `docker.io/library/debian:...` rather than the bare
+  `debian:...`.

--- a/.claude/skills/run-boinc-addons/supervisor.sh
+++ b/.claude/skills/run-boinc-addons/supervisor.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Run the add-ons under a real Home Assistant Supervisor, not plain Docker.
+#
+# Wraps the repo's .devcontainer (ghcr.io/home-assistant/devcontainer:2-addons) from the
+# command line, applying the workarounds documented in SKILL.md. Everything happens inside
+# one privileged container named $CONTAINER; the repo itself is never modified.
+set -euo pipefail
+
+CONTAINER="ha-addons-dev"
+IMAGE="ghcr.io/home-assistant/devcontainer:2-addons"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HA_URL="http://localhost:7123"
+
+# Supervisor reads the local store from /data/apps/local (the addons -> apps rename);
+# devcontainer_bootstrap still mounts into the legacy addons/local, so we place add-ons here.
+APPS_LOCAL="/mnt/supervisor/apps/local"
+
+indocker() { docker exec "$CONTAINER" bash -lc "$1"; }
+ha() { indocker "docker exec hassio_cli ha $1 --no-progress"; }
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <command> [addon]
+
+  up                 start the devcontainer and boot Supervisor (idempotent)
+  install <addon>    stage boinc|boinctui into the local store, build it, install and start it
+  logs <addon>       tail that add-on's log as Supervisor sees it
+  status             list installed apps and the Supervisor container states
+  down               remove the devcontainer and its volumes (frees ~5GB)
+
+Home Assistant UI: $HA_URL
+EOF
+}
+
+require_addon() {
+    case "${1:-}" in
+        boinc | boinctui) ;;
+        *)
+            echo "error: expected 'boinc' or 'boinctui', got '${1:-}'" >&2
+            exit 1
+            ;;
+    esac
+}
+
+supervisor_running() {
+    indocker 'docker inspect -f "{{.State.Status}}" hassio_supervisor 2>/dev/null' 2>/dev/null | grep -q running
+}
+
+cmd_up() {
+    if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+        echo "==> starting devcontainer $CONTAINER"
+        docker run -d --name "$CONTAINER" --privileged \
+            -e WORKSPACE_DIRECTORY=/workspaces/boinc-addons \
+            -v "$REPO_ROOT:/workspaces/boinc-addons" \
+            -v ha-dev-docker:/var/lib/docker \
+            -v ha-dev-supervisor:/mnt/supervisor \
+            -p 7123:8123 -p 7357:4357 -p 21416:31416 \
+            "$IMAGE" sleep infinity >/dev/null
+        indocker 'bash /usr/bin/supervisor_bootstrap'
+    fi
+
+    if supervisor_running; then
+        echo "==> Supervisor already running"
+    else
+        echo "==> booting Supervisor (first run pulls ~2GB of HA images, several minutes)"
+        # Home Assistant Core bind-mounts /run/supervisor; it is created on the very first boot
+        # and lost if Supervisor is restarted by hand, which then fails Core with
+        # `bind source path does not exist`.
+        indocker 'mkdir -p /run/supervisor'
+        # -t is required: supervisor_run calls `stty sane`, which fails without a TTY and,
+        # under `set -e`, kills the script right after dockerd starts.
+        docker exec -dt "$CONTAINER" bash -lc 'supervisor_run > /tmp/supervisor.log 2>&1'
+    fi
+
+    # Readiness is the Supervisor API, not the Home Assistant UI: add-ons install and run
+    # through Supervisor alone, and Core takes several more minutes to come up.
+    echo "==> waiting for the Supervisor API"
+    until ha 'supervisor info' >/dev/null 2>&1; do sleep 5; done
+
+    # In docker-in-docker the gateway health check fails, and an unhealthy system refuses
+    # every install with `blocked from execution, system is not healthy`.
+    ha 'jobs options --ignore-conditions healthy' >/dev/null
+    echo "==> ready: $HA_URL"
+}
+
+cmd_install() {
+    local addon="$1"
+    require_addon "$addon"
+    supervisor_running || {
+        echo "error: Supervisor is not running, run '$(basename "$0") up' first" >&2
+        exit 1
+    }
+
+    echo "==> staging $addon into the local store"
+    # A copy, not a bind mount: Supervisor keeps submounts from its own start in its mount
+    # namespace, so a mount added later is invisible to it until it is restarted.
+    indocker "rm -rf $APPS_LOCAL/$addon && cp -r /workspaces/boinc-addons/$addon $APPS_LOCAL/$addon"
+    # With `image:` set, Supervisor pulls the published image instead of building the local
+    # source -- and a version that is not released yet fails with a 404 manifest.
+    indocker "sed -i 's|^image: |# image: |' $APPS_LOCAL/$addon/config.yaml"
+
+    ha 'store reload' >/dev/null
+    sleep 5
+
+    echo "==> building and installing local_$addon (first build takes several minutes)"
+    ha "store apps install local_$addon"
+    ha "apps start local_$addon"
+    ha "apps info local_$addon --raw-json" 2>/dev/null |
+        docker exec -i "$CONTAINER" jq -r '.data | {slug, version, state, protected}'
+}
+
+cmd_logs() {
+    require_addon "${1:-}"
+    ha "apps logs local_$1"
+}
+
+cmd_status() {
+    indocker 'docker ps --format "{{.Names}}\t{{.Status}}"'
+    echo
+    ha 'apps' | grep -E 'slug:|name:|version:|state:' || echo '(no apps installed)'
+}
+
+cmd_down() {
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker volume rm ha-dev-docker ha-dev-supervisor >/dev/null 2>&1 || true
+    echo "==> removed $CONTAINER and its volumes"
+}
+
+case "${1:-}" in
+    up) cmd_up ;;
+    install) cmd_install "${2:-}" ;;
+    logs) cmd_logs "${2:-}" ;;
+    status) cmd_status ;;
+    down) cmd_down ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,13 @@ See [boinc/DEVELOPMENT.md](boinc/DEVELOPMENT.md) for the `docker build`/`docker 
 `boinc/operator/options.json` is the sample options file those commands (and CI's smoke test)
 mount in.
 
+Plain Docker only exercises the container. Anything Supervisor does *around* it —
+`config.yaml`/`build.yaml` validation, the option schema, `translations/`, ingress, protection
+mode, watchdog — needs a real Supervisor, which nothing in CI covers. The repo's `.devcontainer`
+provides one; `.claude/skills/run-boinc-addons/supervisor.sh` drives it from the command line
+(`up` / `install <addon>` / `logs` / `status` / `down`). Worth running before releasing a change
+to any of those files.
+
 ### Docs site
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -171,10 +171,11 @@ presentation pages, fetched 2026-08-08). Ordered roughly by impact.
   `es.yaml` is a faithful Spanish translation of the wrong thing, so Supervisor finds no
   `configuration:` block and silently falls back to English for every option label. Fix is
   mechanical: revert the four structural key names, keep all the Spanish strings.
-  (Side note: `network:` as a top-level translations key is used by `en.yaml` for the
-  `31416/tcp` port description — it did not appear in the docs pages fetched, so **verify it's a
-  supported key** rather than assuming; if it isn't, port descriptions need `ports_description:`
-  in `config.yaml` instead.)
+  (Side note, now resolved: `network:` **is** a supported top-level translations key. Verified
+  against a running Supervisor 2026-08-09 — it validates the key and rejects only bad *values*,
+  as seen on another add-on: `Can't read translations from .../adguard/translations/en.yaml -
+  expected str for dictionary value @ data['network']['53/udp']`. Our `31416/tcp` value is a
+  plain string, so it is fine. No `ports_description:` needed.)
 
 - [ ] **`icon.png` violates the documented aspect-ratio requirement in both apps.**
   Docs: "The aspect ratio of the icon must be 1x1 (square)", recommended 128x128px. Actual
@@ -214,18 +215,38 @@ presentation pages, fetched 2026-08-08). Ordered roughly by impact.
 ### Deprecated / template-copied config worth modernizing
 
 - [ ] **`map:` uses the legacy plain-string form.** `boinc/config.yaml:31-32` is
-  `map: [addon_config]`; the documented format is now structured:
-  ```yaml
-  map:
-    - type: addon_config
-      read_only: false
+  `map: [addon_config]`. **Corrected against a running Supervisor (2026-08-09): the
+  replacement is `app_config`, not the `type: addon_config` structured form recorded
+  here earlier.** Supervisor says so itself on every store scan:
   ```
-  with "Defaults to read-only, which you can change by adding the property read_only: false".
+  WARNING [supervisor.apps.validate] App 'BOINC' uses legacy map type 'addon_config';
+    use 'app_config' instead.
+  ```
+  The structured form with `read_only: false` is still how you opt out of the read-only
+  default ("Defaults to read-only, which you can change by adding the property read_only: false"),
+  so the target is presumably `- type: app_config` + `read_only: false` — verify the exact
+  accepted shape against Supervisor before changing it, the same way this was caught.
   This used to interact with the `global_prefs_override.py` clobber bug at the top of this file —
   a read-only mount turned the write-through-the-symlink into an uncaught `OSError` and a startup
   crash loop rather than silent truncation. **The early-`return` fix in 3.8.0 removed both failure
   modes**, so this item is now purely about modernizing the `map:` syntax and making the
   `read_only` intent explicit rather than inherited from a default.
+
+- [ ] **`build.yaml` itself is deprecated.** Supervisor, on every store scan:
+  `App local_boinc uses build.yaml which is deprecated. Move build parameters into the
+  Dockerfile directly.` Both add-ons still ship one. Note this does **not** compose with simply
+  deleting the file: Supervisor passes `--build-arg BUILD_FROM=<its default>` regardless, which
+  overrides the `ARG BUILD_FROM="docker.io/library/debian:13.6-slim"` default in the Dockerfile.
+  Work out what the supported replacement actually is before removing anything — the
+  `build_from` regex bug fixed in `boinc` 3.8.0 / `boinctui` 2.4.1 was found exactly here.
+
+- [ ] **`boinctui` sets `panel_icon` but never `ingress_panel: true`.**
+  `boinctui/config.yaml:10-12` has `ingress: true`, `ingress_port: 7681`, `panel_icon: mdi:console`.
+  Under a running Supervisor the installed add-on reports `"ingress_panel": false`, so the icon
+  configures a sidebar panel that is not enabled — ingress works (a real
+  `/api/hassio_ingress/<token>/` URL is issued), it just isn't in the sidebar. Check in the UI
+  whether a sidebar entry is wanted; if it is, add `ingress_panel: true`, if not, `panel_icon`
+  is dead config.
 
 - [ ] **`init: false` isn't justified by the documented reason, and `main.py` silently depends on
   it.** Docs: `init` defaults `true`; disable it "if the image has a custom init system (e.g.
@@ -286,9 +307,22 @@ adding (each is a `dict2xml` key away, same pattern as `global_prefs_override.py
 
 ## Test coverage
 
-- [ ] `test_global_prefs_override.py` needs a case that supplies a config-dir override file
+- [x] **Done in `boinc` 3.8.0** — `test_should_not_overwrite_a_linked_global_prefs_override`.
+  `test_global_prefs_override.py` needs a case that supplies a config-dir override file
   *and* schedule/CPU options together, asserting the override file's original bytes survive —
   this is exactly the scenario the bug above breaks silently.
+
+- [ ] **Nothing exercises the Home Assistant surface in CI**, only the container. Everything under
+  "Conformance with the official HA apps docs" above is invisible to `docker build`/`docker run`:
+  `config.yaml`/`build.yaml` validation, option schema, translations, ingress, protection mode,
+  watchdog. There is now a local path for it —
+  `.claude/skills/run-boinc-addons/supervisor.sh` boots the repo's `.devcontainer` with a real
+  Supervisor and installs the add-on from the working tree — and it immediately paid for itself
+  (the `build_from` bug, the `app_config` correction, the `network:` verification, the
+  `ingress_panel` finding). Putting it in CI is a different question: Supervisor in
+  docker-in-docker needs `--privileged`, a TTY, a health-check override, and pulls ~2GB, so it is
+  slow and fragile. Realistic middle ground: keep it a documented manual step before releases that
+  touch `config.yaml`/`build.yaml`/`translations/`, and revisit a nightly (not per-PR) job later.
 - [ ] No test currently asserts on `gui_rpc_auth.py` logging behavior specifically (low
   priority — cosmetic — but flagging alongside the `venv.logger` import finding).
 - [ ] No test covers `main.py`'s exit-code/signal behavior (the `--exit-immediately` parsing bug,

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,10 @@ resolved or discarded.
 
 ## Bugs / correctness
 
-- [ ] **`global_prefs_override.py` clobbers a user-supplied override file on every start.**
+- [x] **Fixed in `boinc` 3.8.0** — early `return` after the symlink branch, plus
+  `test_should_not_overwrite_a_linked_global_prefs_override` asserting the content of both the
+  `/config` file and the data-folder path.
+  **`global_prefs_override.py` clobbers a user-supplied override file on every start.**
   `link_global_prefs_override` (`boinc/operator/global_prefs_override.py:9-40`) symlinks
   `/config/global_prefs_override.xml` into the data folder when it exists (lines 15-19), but
   then falls through unconditionally to lines 21-40, which build a `preferences` dict from
@@ -58,7 +61,11 @@ resolved or discarded.
   via `docker kill`/`SIGTERM` from another terminal. If the intent was "don't forward SIGINT to
   BOINC," the operator itself still needs to exit in that branch instead of silently continuing.
 
-- [ ] **The operator always exits with code 0, even when startup fails.**
+- [x] **Fixed in `boinc` 3.8.0** — `sys.exit(1)` when `configure_boinc_projects` fails, and the
+  BOINC client's own exit code is propagated when it is positive (a negative code means the client
+  was signaled, which is how both a Supervisor stop and `--exit-immediately` end it — still 0).
+  This unblocks the `watchdog:` item below.
+  **The operator always exits with code 0, even when startup fails.**
   `boinc/operator/main.py` never calls `sys.exit(...)` (no `import sys` at all). When
   `configure_boinc_projects` fails (e.g. wrong account-manager credentials) it stops the BOINC
   process (`main.py:80-82`) and the script then falls through the rest of main.py and ends
@@ -80,7 +87,12 @@ with its account manager on its own schedule, so a loop would mostly duplicate t
 half of the pattern is **field ownership**: an option the user never set is a field the operator
 does not own and must not touch. Both bugs below are that rule being missing.
 
-- [ ] **An account manager attached from `boinctui` is silently detached on the next restart.**
+- [x] **Fixed in `boinc` 3.8.0** — unset options now mean "not a field the operator owns": it logs
+  the externally-attached account manager and leaves it alone. New `test/test_boinccmd.py` covers
+  this and the four other branches. Follow-up left open: **there is now no way to express "detach
+  it" through the options**; `boinc/DOCS.md` documents `boinccmd --acct_mgr detach` as the manual
+  route, but an explicit gate (empty string, or `manage_account_manager: bool`) would be better.
+  **An account manager attached from `boinctui` is silently detached on the next restart.**
   `configure_boinc_projects` (`boinc/operator/boinccmd.py:84-88`) treats "all three
   `account_manager_*` options unset" as the desired state *no account manager*, and calls
   `detach_account_manager`. But all three are optional (`boinc/config.yaml:21-23`, `str?`/
@@ -110,7 +122,9 @@ does not own and must not touch. Both bugs below are that rule being missing.
 
 ## Security / permissions — needs documentation or review
 
-- [ ] **Secrets are logged in plaintext at `DEBUG` level.**
+- [x] **Fixed in `boinc` 3.8.0** — new `operator/redact.py` replaces `gui_rpc_password` and
+  `account_manager_password` with `***` before the dump, covered by `test/test_redact.py`.
+  **Secrets are logged in plaintext at `DEBUG` level.**
   `boinc/operator/main.py:37`: `logging.debug(f'Current configuration\n{json.dumps(options, indent=2)}')`
   dumps the entire parsed `options.json`, including `gui_rpc_password` and
   `account_manager_password` (both `password?` in the schema, `boinc/config.yaml:17,23`), verbatim
@@ -140,7 +154,9 @@ presentation pages, fetched 2026-08-08). Ordered roughly by impact.
 
 ### Broken / non-functional
 
-- [ ] **`boinc/translations/es.yaml` is entirely non-functional — the structural keys are
+- [x] **Fixed in `boinc` 3.8.0** — the four structural keys are back in English, all Spanish
+  strings kept. The `network:` caveat below is unchanged and still unverified.
+  **`boinc/translations/es.yaml` is entirely non-functional — the structural keys are
   translated too.** The file uses `configuración:` / `nombre:` / `descripción:` / `red:` where
   the format requires the literal English keys `configuration:` / `name:` / `description:`
   (`network:`). Per the configuration docs the shape is fixed:
@@ -205,14 +221,11 @@ presentation pages, fetched 2026-08-08). Ordered roughly by impact.
       read_only: false
   ```
   with "Defaults to read-only, which you can change by adding the property read_only: false".
-  **This interacts with the `global_prefs_override.py` clobber bug at the top of this file**: if
-  the mount is read-only (which is the default in both the legacy and documented forms), then the
-  unconditional `open(gui_rpc_auth, 'w')` writing *through* the symlink into `/config` doesn't
-  silently truncate the user's file — it raises `OSError`, uncaught, and the operator dies before
-  BOINC ever starts. So the documented "Preferences Override" feature (`boinc/README.md:152-154`)
-  may currently produce a **startup crash loop**, not just data loss. Needs verification on a real
-  Supervisor install to know which of the two failure modes users actually hit; either way the
-  early-`return` fix resolves both.
+  This used to interact with the `global_prefs_override.py` clobber bug at the top of this file —
+  a read-only mount turned the write-through-the-symlink into an uncaught `OSError` and a startup
+  crash loop rather than silent truncation. **The early-`return` fix in 3.8.0 removed both failure
+  modes**, so this item is now purely about modernizing the `map:` syntax and making the
+  `read_only` intent explicit rather than inherited from a default.
 
 - [ ] **`init: false` isn't justified by the documented reason, and `main.py` silently depends on
   it.** Docs: `init` defaults `true`; disable it "if the image has a custom init system (e.g.

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.8.0
+
+Fix a custom global_prefs_override.xml being overwritten on every start
+
+Keep an account manager attached outside the app options instead of detaching it
+
+Exit with a non-zero code when startup fails, so a crash is no longer reported as a clean stop
+
+Redact passwords from the configuration dump written at DEBUG log level
+
+Fix the Spanish translation, which used translated structural keys and never applied
+
 ## 3.7.0
 
 Update base from Debian 13.5 to Debian 13.6

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -12,6 +12,8 @@ Redact passwords from the configuration dump written at DEBUG log level
 
 Fix the Spanish translation, which used translated structural keys and never applied
 
+Fix the base image in build.yaml being rejected by Supervisor, which broke building from source
+
 ## 3.7.0
 
 Update base from Debian 13.5 to Debian 13.6

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -56,6 +56,12 @@ There is a boinctui app available for this purpose [here](https://github.com/hec
   - Password for the configured user in the BOINC Account Manager
   - Required if `account_manager_url` is set
 
+When these three options are set, the app keeps the BOINC client attached to that account manager,
+replacing a different one if needed. When they are left empty, the app does not touch the account
+manager at all: an account manager you attached yourself — from the boinctui app, a remote BOINC
+Manager, or `boinccmd` — is left as it is. Detaching it is done the same way you attached it, for
+example `boinccmd --acct_mgr detach`.
+
 #### Remote Control Options
 
 - **gui_rpc_password** (optional)

--- a/boinc/build.yaml
+++ b/boinc/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: debian:13.6-slim
-  amd64: debian:13.6-slim
+  aarch64: docker.io/library/debian:13.6-slim
+  amd64: docker.io/library/debian:13.6-slim
 labels:
   org.opencontainers.image.title: "Boinc add-on"
   org.opencontainers.image.description: "Home Assistant Boinc add-on."

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC
-version: "3.7.0"
+version: "3.8.0"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"

--- a/boinc/operator/boinccmd.py
+++ b/boinc/operator/boinccmd.py
@@ -81,10 +81,10 @@ def configure_boinc_projects(data_folder: str, account_manager_url: str | None, 
 
             return attach_account_manager(data_folder, account_manager_url, account_manager_username, account_manager_password)
 
-    elif current_account_manager_url is not None and account_manager_url is None and account_manager_username is None and account_manager_password is None:
-        logging.debug(f'Account manager {current_account_manager_url} not configured, detaching')
-        if not detach_account_manager(data_folder):
-            return False
-
+    elif current_account_manager_url is not None:
+        # No account manager is configured in the add-on options, so this is not a field the
+        # operator owns: the attachment was made outside it (boinctui, a remote GUI, boinccmd).
+        # Leaving it alone, detaching it here would silently undo the user's own configuration.
+        logging.info(f'Account manager {current_account_manager_url} was attached outside the add-on options, leaving it unchanged')
 
     return True

--- a/boinc/operator/global_prefs_override.py
+++ b/boinc/operator/global_prefs_override.py
@@ -17,6 +17,7 @@ def link_global_prefs_override(data_folder: str, config_folder: str, data: dict)
         os.symlink(configured_gui_rpc_auth, gui_rpc_auth)
         logging.debug(f'Linked global_prefs_override.xml to {configured_gui_rpc_auth}')
         logging.info(f'Using global_prefs_override.xml to configure BOINC client')
+        return
 
     preferences = {}
 

--- a/boinc/operator/main.py
+++ b/boinc/operator/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 from time import sleep
 
 from boinc import build_boinc_command
@@ -12,6 +13,7 @@ from cc_config import prepare_cc_config
 from folders import prepare_data_folders
 from global_prefs_override import link_global_prefs_override
 from gui_rpc_auth import prepare_gui_rpc_auth
+from redact import redact_secrets
 from remote_hosts import prepare_remote_hosts
 
 parser = argparse.ArgumentParser(prog='operator')
@@ -34,7 +36,7 @@ if current_pid == 1:
 logging.info(f'Configuration loaded from {args.options.name}')
 
 options = json.load(args.options)
-logging.debug(f'Current configuration\n{json.dumps(options, indent=2)}')
+logging.debug(f'Current configuration\n{json.dumps(redact_secrets(options), indent=2)}')
 
 data_folder = args.data
 logging.info(f'BOINC data folder {data_folder}')
@@ -55,10 +57,14 @@ logging.debug(f'BOINC client command {boinc_command}')
 boinc_process = subprocess.Popen(boinc_command)
 logging.debug(f'BOINC client started with pid {boinc_process.pid}')
 
+stopping_boinc_process = False
+
 def signal_handler(number, frame):
+    global stopping_boinc_process
     logging.debug(f'Caught signal {number}')
     if  number != signal.SIGINT and boinc_process.poll() is None:
         logging.debug(f'Stopping BOINC client with signal {number}')
+        stopping_boinc_process = True
         boinc_process.send_signal(number)
 
 logging.info(f'BOINC Add-on Operator started')
@@ -80,9 +86,12 @@ projects_configured = configure_boinc_projects(data_folder, options.get('account
 if not projects_configured:
     boinc_process.send_signal(signal.SIGTERM)
     boinc_process.wait()
+    logging.error(f'BOINC Add-on Operator stopped: failed to configure BOINC projects')
+    sys.exit(1)
 
 if args.exit_immediately:
     logging.warning(f'Exiting immediately after BOINC client is started')
+    stopping_boinc_process = True
     boinc_process.send_signal(signal.SIGTERM)
     boinc_process.wait()
 
@@ -90,4 +99,11 @@ while boinc_process.poll() is None:
     sleep(0.5)
 
 logging.debug(f'BOINC client stopped with code {boinc_process.returncode}')
+
+# Only a client that stopped on its own is a failure: the operator asking it to stop is how both a
+# Supervisor stop and --exit-immediately end, whatever code the client reports for that.
+if not stopping_boinc_process and boinc_process.returncode != 0:
+    logging.error(f'BOINC Add-on Operator stopped: BOINC client exited with code {boinc_process.returncode}')
+    sys.exit(1)
+
 logging.info(f'BOINC Add-on Operator stopped')

--- a/boinc/operator/redact.py
+++ b/boinc/operator/redact.py
@@ -1,0 +1,6 @@
+SECRET_OPTIONS = ('gui_rpc_password', 'account_manager_password')
+
+REDACTED = '***'
+
+def redact_secrets(options: dict) -> dict:
+    return {key: REDACTED if key in SECRET_OPTIONS and value is not None else value for key, value in options.items()}

--- a/boinc/operator/test/test_boinccmd.py
+++ b/boinc/operator/test/test_boinccmd.py
@@ -1,0 +1,92 @@
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from boinccmd import configure_boinc_projects
+
+ACCOUNT_MANAGER_URL = 'https://scienceunited.org'
+ACCOUNT_MANAGER_USERNAME = 'a username'
+ACCOUNT_MANAGER_PASSWORD = 'a password'
+
+
+def completed(stdout: str = '', returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr='')
+
+
+def account_manager_info(url: str | None) -> subprocess.CompletedProcess:
+    if url is None:
+        return completed('Account manager info:\n   Name: \n   URL: \n')
+    return completed(f'Account manager info:\n   Name: Science United\n   URL: {url}\n')
+
+
+def executed_commands(run) -> list:
+    return [call.args[0][1:] for call in run.call_args_list]
+
+
+class ConfigureBoincProjectsTestCase(unittest.TestCase):
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_keep_an_account_manager_attached_outside_the_options(self, run):
+        run.return_value = account_manager_info(ACCOUNT_MANAGER_URL)
+
+        self.assertTrue(configure_boinc_projects('a data folder', None, None, None))
+
+        self.assertEqual(executed_commands(run), [['--acct_mgr', 'info']])
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_do_nothing_when_nothing_is_configured_nor_attached(self, run):
+        run.return_value = account_manager_info(None)
+
+        self.assertTrue(configure_boinc_projects('a data folder', None, None, None))
+
+        self.assertEqual(executed_commands(run), [['--acct_mgr', 'info']])
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_attach_the_configured_account_manager(self, run):
+        run.side_effect = [account_manager_info(None), completed()]
+
+        self.assertTrue(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD))
+
+        self.assertEqual(executed_commands(run), [
+            ['--acct_mgr', 'info'],
+            ['--acct_mgr', 'attach', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD],
+        ])
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_synchronize_an_already_attached_account_manager(self, run):
+        run.side_effect = [account_manager_info(ACCOUNT_MANAGER_URL), completed()]
+
+        self.assertTrue(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD))
+
+        self.assertEqual(executed_commands(run), [['--acct_mgr', 'info'], ['--acct_mgr', 'sync']])
+
+    @patch('boinccmd.sleep')
+    @patch('boinccmd.subprocess.run')
+    def test_should_replace_a_different_account_manager(self, run, sleep):
+        run.side_effect = [account_manager_info('https://another.account.manager'), completed(), completed()]
+
+        self.assertTrue(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD))
+
+        self.assertEqual(executed_commands(run), [
+            ['--acct_mgr', 'info'],
+            ['--acct_mgr', 'detach'],
+            ['--acct_mgr', 'attach', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD],
+        ])
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_not_configure_a_partially_configured_account_manager(self, run):
+        run.return_value = account_manager_info(None)
+
+        self.assertTrue(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, None, None))
+
+        self.assertEqual(executed_commands(run), [['--acct_mgr', 'info']])
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_fail_when_the_account_manager_information_is_not_available(self, run):
+        run.return_value = completed(returncode=1)
+
+        self.assertFalse(configure_boinc_projects('a data folder', None, None, None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/boinc/operator/test/test_global_prefs_override.py
+++ b/boinc/operator/test/test_global_prefs_override.py
@@ -33,6 +33,28 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
             self.assertTrue(os.path.exists(f'{tmp_dir}/data/global_prefs_override.xml'))
             self.assertTrue(os.path.islink(f'{tmp_dir}/data/global_prefs_override.xml'))
 
+    def test_should_not_overwrite_a_linked_global_prefs_override(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_dir = f'{tmp_dir}/data'
+            os.makedirs(data_dir)
+            config_dir = f'{tmp_dir}/config'
+            os.makedirs(config_dir)
+
+            configured_preferences = '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>'
+            with open(f'{config_dir}/global_prefs_override.xml', 'w') as f:
+                f.write(configured_preferences)
+
+            link_global_prefs_override(data_dir, config_dir, {
+                'start_hour': '00:35',
+                'end_hour': '08:59'
+            })
+
+            with open(f'{config_dir}/global_prefs_override.xml', 'r') as f:
+                self.assertEqual(f.read(), configured_preferences)
+
+            with open(f'{data_dir}/global_prefs_override.xml', 'r') as f:
+                self.assertEqual(f.read(), configured_preferences)
+
     def test_should_create_global_prefs_override_with_configuration(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             data_dir = f'{tmp_dir}/data'

--- a/boinc/operator/test/test_redact.py
+++ b/boinc/operator/test/test_redact.py
@@ -1,0 +1,50 @@
+import unittest
+
+from redact import redact_secrets
+
+
+class RedactTestCase(unittest.TestCase):
+
+    def test_should_redact_passwords(self):
+        options = {
+            'gui_rpc_password': 'a gui rpc password',
+            'account_manager_password': 'an account manager password',
+        }
+
+        self.assertEqual(redact_secrets(options), {
+            'gui_rpc_password': '***',
+            'account_manager_password': '***',
+        })
+
+    def test_should_keep_non_secret_options(self):
+        options = {
+            'gui_rpc_password': 'a gui rpc password',
+            'account_manager_url': 'https://scienceunited.org',
+            'account_manager_username': 'a username',
+            'remote_hosts': ['a-host'],
+            'max_ncpus': 50,
+        }
+
+        self.assertEqual(redact_secrets(options), {
+            'gui_rpc_password': '***',
+            'account_manager_url': 'https://scienceunited.org',
+            'account_manager_username': 'a username',
+            'remote_hosts': ['a-host'],
+            'max_ncpus': 50,
+        })
+
+    def test_should_not_redact_unset_passwords(self):
+        options = {'gui_rpc_password': None, 'account_manager_password': None}
+
+        self.assertEqual(redact_secrets(options), {'gui_rpc_password': None, 'account_manager_password': None})
+
+    def test_should_not_modify_the_original_options(self):
+        options = {'gui_rpc_password': 'a gui rpc password'}
+
+        redact_secrets(options)
+
+        self.assertEqual(options, {'gui_rpc_password': 'a gui rpc password'})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/boinc/translations/es.yaml
+++ b/boinc/translations/es.yaml
@@ -1,33 +1,33 @@
-configuración:
+configuration:
   gui_rpc_password:
-    nombre: "Contraseña GUI RPC"
-    descripción: "Definir una contraseña GUI RPC para conectarse de forma remota"
+    name: "Contraseña GUI RPC"
+    description: "Definir una contraseña GUI RPC para conectarse de forma remota"
   remote_hosts:
-    nombre: Hosts remotos
-    descripción: Lista de hosts remotos para permitir la conexión remota
+    name: Hosts remotos
+    description: Lista de hosts remotos para permitir la conexión remota
   allow_remote_gui_rpc:
-    nombre: Permitir GUI RPC remota
-    descripción: Permitir todas las conexiones GUI RPC remotas (Anula los hosts remotos)
+    name: Permitir GUI RPC remota
+    description: Permitir todas las conexiones GUI RPC remotas (Anula los hosts remotos)
   account_manager_url:
-    nombre: URL del Gestor de Cuentas
-    descripción: "URL de un Gestor de Cuentas BOINC, por ejemplo: https://scienceunited.org"
+    name: URL del Gestor de Cuentas
+    description: "URL de un Gestor de Cuentas BOINC, por ejemplo: https://scienceunited.org"
   account_manager_username:
-    nombre: Nombre de Usuario del Gestor de Cuentas
-    descripción: "Nombre de usuario registrado en el Gestor de Cuentas BOINC"
+    name: Nombre de Usuario del Gestor de Cuentas
+    description: "Nombre de usuario registrado en el Gestor de Cuentas BOINC"
   account_manager_password:
-    nombre: Contraseña del Gestor de Cuentas
-    descripción: "Contraseña del usuario configurado en el Gestor de Cuentas BOINC"
+    name: Contraseña del Gestor de Cuentas
+    description: "Contraseña del usuario configurado en el Gestor de Cuentas BOINC"
   start_hour:
-    nombre: Hora de Inicio
-    descripción: "Hora en que BOINC comienza a computar"
+    name: Hora de Inicio
+    description: "Hora en que BOINC comienza a computar"
   end_hour:
-    nombre: Hora de Fin
-    descripción: "Hora en que BOINC deja de computar"
+    name: Hora de Fin
+    description: "Hora en que BOINC deja de computar"
   max_ncpus:
-    nombre: Porcentaje Máximo de CPUs
-    descripción: "Número máximo de CPUs a utilizar"
+    name: Porcentaje Máximo de CPUs
+    description: "Número máximo de CPUs a utilizar"
   cpu_usage_limit:
-    nombre: Porcentaje Máximo de Uso de CPU
-    descripción: "Tiempo máximo de uso por CPU"
-red:
+    name: Porcentaje Máximo de Uso de CPU
+    description: "Tiempo máximo de uso por CPU"
+network:
   31416/tcp: Puerto GUI RPC del cliente BOINC (por defecto 31416)

--- a/boinctui/CHANGELOG.md
+++ b/boinctui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1
+
+Fix the base image in build.yaml being rejected by Supervisor, which broke building from source
+
 ## 2.4.0
 
 Update base from Debian 13.5 to Debian 13.6

--- a/boinctui/build.yaml
+++ b/boinctui/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: debian:13.6-slim
-  amd64: debian:13.6-slim
+  aarch64: docker.io/library/debian:13.6-slim
+  amd64: docker.io/library/debian:13.6-slim
 labels:
   org.opencontainers.image.title: "boinctui add-on"
   org.opencontainers.image.description: "Home Assistant boinctui add-on."

--- a/boinctui/config.yaml
+++ b/boinctui/config.yaml
@@ -1,5 +1,5 @@
 name: boinctui
-version: "2.4.0"
+version: "2.4.1"
 slug: boinctui
 description: Fullscreen text mode manager for BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinctui"


### PR DESCRIPTION
Fixes the five bugs ranked highest by impact in [`TODO.md`](../blob/main/TODO.md), all in the `boinc` app. Version bumped to **3.8.0** with a matching `CHANGELOG.md` section.

## 1. "Preferences Override" was broken — with two possible failure modes

`link_global_prefs_override` symlinked a user-supplied `/config/global_prefs_override.xml` into the data folder and then **fell through without returning** to the generator, whose `open(..., 'w')` wrote *through* the symlink it had just created.

- On a writable `addon_config` mount: the user's custom XML was truncated and replaced on every start.
- On a read-only mount (the documented default for `map:`): an uncaught `OSError`, so the operator died before BOINC ever started — a startup crash loop.

A documented feature (`boinc/README.md`) that likely worked for nobody. Fixed with an early `return`; `test_should_link_global_prefs_override` only asserted that the symlink existed, so a new test now asserts the *content* of both the `/config` file and the data-folder path.

## 2. An account manager attached outside the options was silently detached

All three `account_manager_*` options are optional, so "unset" is also the state of a user who never wanted the operator to manage this and attached their account manager interactively from `boinctui`, a remote BOINC Manager or `boinccmd`. `configure_boinc_projects` read that as *desired state: no account manager* and called `detach_account_manager`, with a single `logging.debug` line as the only trace.

Now unset options mean the field is not one the operator owns, and it is left alone.

**Behaviour change worth reviewing:** detaching is no longer expressible through the options. `boinc/DOCS.md` documents `boinccmd --acct_mgr detach` as the manual route; an explicit gate (empty string, or a `manage_account_manager` boolean) is left as a follow-up in `TODO.md`.

## 3. The operator always exited 0, even when startup failed

`main.py` never called `sys.exit` (it did not even import `sys`). Bad account-manager credentials stopped the BOINC client and then ended normally — indistinguishable, from Supervisor's point of view, from a deliberate stop. This is also why adding a `watchdog:` would have been pointless, so it unblocks that item.

A client that stopped on its own now produces a failure; a stop the operator asked for (Supervisor signal, `--exit-immediately`) still exits 0, whatever code the client reports for it — which keeps the CI smoke test honest.

## 4. Passwords were logged in plaintext at DEBUG level

`logging.debug(f'Current configuration\n{json.dumps(options, …)}')` dumped `gui_rpc_password` and `account_manager_password` verbatim. Not hypothetical: CI runs the image with `--log-level DEBUG`, so every build published the sample password to a public Actions log, and a user who enables DEBUG to troubleshoot something else would leak their real one into any issue they paste logs into.

New `operator/redact.py` replaces both with `***` before the dump.

## 5. The Spanish translation never applied

`boinc/translations/es.yaml` had the *structural* keys translated too (`configuración:`, `nombre:`, `descripción:`, `red:`) where the format requires the literal English keys. Supervisor found no `configuration:` block and silently fell back to English for every option label — the whole translation was dead. Structural keys reverted, all Spanish strings kept.

## 6. `build.yaml` was rejected by Supervisor, so neither add-on could be built from source

Found by installing the add-on into a real Supervisor rather than plain Docker. Supervisor validates `build_from` against `^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$`, which requires an `owner/name` pair. Official images have no namespace, so `debian:13.6-slim` fails it and the **whole** build config is discarded:

```
WARNING [supervisor.apps.build] Error parsing local_boinc build config
  (does not match regular expression ... @ data['build_from']['aarch64']), using defaults
-> --build-arg BUILD_FROM=ghcr.io/home-assistant/base:latest
-> /bin/bash: line 1: apt-get: command not found
```

The fallback base is Alpine, so every `RUN` in either Dockerfile dies. Fixed by pinning `docker.io/library/debian:13.6-slim`.

Production is unaffected — `image:` makes Supervisor pull the published image instead of building — and CI never saw it because the release pipeline builds the images itself, never through Supervisor's validation. It broke anyone building from source.

`boinc` rides along in the unreleased 3.8.0; **`boinctui` is bumped to 2.4.1** because 2.4.0 is already tagged.

## Supervisor mode for the `run-boinc-addons` skill

Nothing in this repo could test the Home Assistant *surface* of the add-ons — only the container. New `.claude/skills/run-boinc-addons/supervisor.sh` boots the repo's existing (previously unused) `.devcontainer` with a full Supervisor stack and installs an add-on from the working tree: `up` / `install <addon>` / `logs` / `status` / `down`. `SKILL.md` documents the five traps it handles — `supervisor_run` needing a TTY, the docker-in-docker health check blocking every install, the `addons/local` vs `apps/local` path skew, `image:` shadowing the local source, and `/run/supervisor` vanishing on a manual Supervisor restart.

`TODO.md` is corrected from what the running Supervisor actually reported: the `map:` replacement is **`app_config`**, not the structured `type: addon_config` recorded earlier; `network:` is confirmed a supported translations key (caveat closed); and two new items are added (`build.yaml` itself is deprecated, and `boinctui` sets `panel_icon` without `ingress_panel`).

## Verification

- `python -m unittest discover -s test -t test` → **27 tests, OK**. New `test/test_boinccmd.py` covers all branches of `configure_boinc_projects` (including a regression guard that a *different* account manager is still replaced), plus `test/test_redact.py`.
- `yamllint .` clean.
- Exit codes verified end-to-end by running `main.py` against stub `boinc`/`boinccmd` binaries: clean stop → 0, config failure → 1, client crash → 1, external `SIGTERM` → 0.

- Both add-ons built, installed and started under a real Supervisor from the local store: `local_boinc` 3.8.0 and `local_boinctui` 2.4.1 reach `state: started`; the operator's own log shows `Protection Mode is enabled`, `Starting BOINC client version 8.2.15`, and `Current account manager None` — the fix from item 2 running under Supervisor.
- `shellcheck -s bash supervisor.sh` clean.

`TODO.md` is updated: the five items are checked off with what was done, the `map:` item no longer claims a crash loop, and the "no way to express detach" follow-up is recorded.

Not included (still open in `TODO.md`): the swallowed `SIGINT`, `--exit-immediately` parsed with `type=bool`, the netloc-only account-manager comparison, the generated-prefs overwrite of TUI-set keys, the non-square `icon.png`, the missing `watchdog:` and `backup_exclude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP
