### PR TITLE
fix(boinc): ignore an incomplete computing schedule instead of half-applying it

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,12 +76,20 @@ resolved or discarded.
   "crashed"; a bad account-manager password currently looks identical, from the outside, to a
   deliberate stop. Only an *unhandled* Python exception produces a non-zero exit today.
 
-- [x] **Fixed in `boinc` 3.8.3** — when exactly one of the two is set the operator logs a warning
-  and writes neither, so BOINC computes all the time, which is what an unset schedule already
-  means and what `DOCS.md` already promised. Deliberately *not* a startup failure: a soft config
-  mistake should not crash-loop the app now that exit codes propagate (3.8.0). It composes with
-  the three-way merge from 3.8.1 — a window the operator previously wrote is withdrawn when the
-  config becomes incomplete, rather than leaving half of it behind.
+- [x] **Fixed in `boinc` 3.8.3** — the two hours are now written as a pair or not at all, which is
+  what BOINC Manager does (`clientgui/DlgAdvPreferences.cpp` sets
+  `mask.start_hour = mask.end_hour = true`, so a half window is unreachable from its UI). An
+  incomplete pair, *and* an equal pair, are ignored with a warning and BOINC computes all the
+  time — which is what an unset schedule already means and what `DOCS.md` already promised.
+  The equal-pair case was found while answering "what does BOINC Manager do here?": BOINC reads
+  `start_hour == end_hour` as no restriction at all (`TIME_SPAN::suspended` returns false), so
+  `22:00`–`22:00` is not a 24-hour window but the opposite of a schedule. Confirmed against a
+  live client, and BOINC Manager rejects that combination outright with an error dialog
+  (`if (startTime == endTime) ShowErrorMessage(invMsgTimeSpan, ...)`).
+  Deliberately *not* a startup failure: a soft config mistake should not crash-loop the app now
+  that exit codes propagate (3.8.0). It composes with the three-way merge from 3.8.1 — a window
+  the operator previously wrote is withdrawn when the config becomes incomplete, rather than
+  leaving half of it behind.
   **`start_hour` and `end_hour` are documented as a pair but nothing enforces it, and setting
   one alone silently creates a different schedule than the user asked for.**
   `boinc/DOCS.md:90` says end_hour "Must be used together with `start_hour`", but

--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,13 @@ resolved or discarded.
   "crashed"; a bad account-manager password currently looks identical, from the outside, to a
   deliberate stop. Only an *unhandled* Python exception produces a non-zero exit today.
 
-- [ ] **`start_hour` and `end_hour` are documented as a pair but nothing enforces it, and setting
+- [x] **Fixed in `boinc` 3.8.3** — when exactly one of the two is set the operator logs a warning
+  and writes neither, so BOINC computes all the time, which is what an unset schedule already
+  means and what `DOCS.md` already promised. Deliberately *not* a startup failure: a soft config
+  mistake should not crash-loop the app now that exit codes propagate (3.8.0). It composes with
+  the three-way merge from 3.8.1 — a window the operator previously wrote is withdrawn when the
+  config becomes incomplete, rather than leaving half of it behind.
+  **`start_hour` and `end_hour` are documented as a pair but nothing enforces it, and setting
   one alone silently creates a different schedule than the user asked for.**
   `boinc/DOCS.md:90` says end_hour "Must be used together with `start_hour`", but
   `global_prefs_override.py` writes whichever option is set and BOINC fills the missing one with

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.3
+
+Ignore an incomplete computing schedule instead of letting BOINC fill the missing hour with midnight
+
 ## 3.8.2
 
 Let the BOINC client generate its own GUI RPC password when none is configured, instead of writing an empty one

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Ignore an incomplete computing schedule instead of letting BOINC fill the missing hour with midnight
 
+Ignore a computing schedule whose start and end hours are equal, which BOINC reads as no restriction
+
 ## 3.8.2
 
 Let the BOINC client generate its own GUI RPC password when none is configured, instead of writing an empty one

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -95,6 +95,11 @@ example `boinccmd --acct_mgr detach`.
   - Format: 24-hour time (e.g., `18:00`, `06:00`)
   - Must be used together with `start_hour`
 
+Both hours define a single window and only work as a pair. Setting just one of them is ignored,
+with a warning in the log, and BOINC computes all the time — the app does not guess the missing
+half, because BOINC's own default for it is midnight and that would silently produce a window you
+never asked for.
+
 #### Resource Usage Options
 
 - **max_ncpus** (optional, range: 0-100)

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -95,10 +95,14 @@ example `boinccmd --acct_mgr detach`.
   - Format: 24-hour time (e.g., `18:00`, `06:00`)
   - Must be used together with `start_hour`
 
-Both hours define a single window and only work as a pair. Setting just one of them is ignored,
-with a warning in the log, and BOINC computes all the time — the app does not guess the missing
-half, because BOINC's own default for it is midnight and that would silently produce a window you
-never asked for.
+Both hours define a single window and only work as a pair, the same way BOINC Manager always sets
+them together. Setting just one of them, or setting both to the same time, is ignored with a
+warning in the log, and BOINC computes all the time:
+
+- The app does not guess a missing half, because BOINC's own default for it is midnight and that
+  would silently produce a window you never asked for.
+- BOINC reads an equal pair as no restriction at all, so `22:00`–`22:00` is not a 24-hour window;
+  BOINC Manager rejects that combination outright for the same reason.
 
 #### Resource Usage Options
 

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC
-version: "3.8.2"
+version: "3.8.3"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"

--- a/boinc/operator/global_prefs_override.py
+++ b/boinc/operator/global_prefs_override.py
@@ -25,19 +25,26 @@ def build_managed_preferences(data: dict) -> dict:
     start_hour = data.get('start_hour')
     end_hour = data.get('end_hour')
 
+    # The two hours are written as a pair or not at all, the same way BOINC Manager always sets
+    # both in its preferences mask. Anything else is a window the user did not ask for.
     if (start_hour is None) != (end_hour is None):
         # BOINC fills the missing half with its own default of 0, midnight, so writing only one of
         # them produces a window nobody asked for: start_hour alone stops computing at midnight,
-        # end_hour alone never starts before it. Drop the pair and let BOINC compute all the time,
-        # which is what an unset schedule means.
+        # end_hour alone never starts before it. Let BOINC compute all the time instead, which is
+        # what an unset schedule means.
         logging.warning(f'Ignoring the computing schedule: start_hour and end_hour must both be set to define a window')
-        start_hour = end_hour = None
+    elif start_hour is not None:
+        start_hour = convert_time_to_boinc_format(start_hour)
+        end_hour = convert_time_to_boinc_format(end_hour)
 
-    if start_hour is not None:
-        preferences['start_hour'] = convert_time_to_boinc_format(start_hour)
-
-    if end_hour is not None:
-        preferences['end_hour'] = convert_time_to_boinc_format(end_hour)
+        if start_hour == end_hour:
+            # BOINC reads an equal pair as no restriction at all (TIME_SPAN::suspended returns
+            # false when start_hour == end_hour), so it silently means the opposite of a schedule.
+            # BOINC Manager rejects this outright in its own preferences dialog.
+            logging.warning(f'Ignoring the computing schedule: start_hour and end_hour are both {start_hour}, which BOINC reads as no restriction')
+        else:
+            preferences['start_hour'] = start_hour
+            preferences['end_hour'] = end_hour
 
     max_num_cpus = data.get('max_ncpus')
     if max_num_cpus is not None:

--- a/boinc/operator/global_prefs_override.py
+++ b/boinc/operator/global_prefs_override.py
@@ -23,10 +23,19 @@ def build_managed_preferences(data: dict) -> dict:
     preferences = {}
 
     start_hour = data.get('start_hour')
+    end_hour = data.get('end_hour')
+
+    if (start_hour is None) != (end_hour is None):
+        # BOINC fills the missing half with its own default of 0, midnight, so writing only one of
+        # them produces a window nobody asked for: start_hour alone stops computing at midnight,
+        # end_hour alone never starts before it. Drop the pair and let BOINC compute all the time,
+        # which is what an unset schedule means.
+        logging.warning(f'Ignoring the computing schedule: start_hour and end_hour must both be set to define a window')
+        start_hour = end_hour = None
+
     if start_hour is not None:
         preferences['start_hour'] = convert_time_to_boinc_format(start_hour)
 
-    end_hour = data.get('end_hour')
     if end_hour is not None:
         preferences['end_hour'] = convert_time_to_boinc_format(end_hour)
 

--- a/boinc/operator/test/test_global_prefs_override.py
+++ b/boinc/operator/test/test_global_prefs_override.py
@@ -106,6 +106,18 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
                          '<global_preferences>\n</global_preferences>')
         self.assertEqual(self.read_managed_state(), {})
 
+    def test_should_ignore_a_schedule_whose_hours_are_equal(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {
+            'start_hour': '22:00',
+            'end_hour': '22:00'
+        })
+
+        # BOINC reads an equal pair as no restriction at all, so writing it would silently mean the
+        # opposite of a schedule.
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n</global_preferences>')
+        self.assertEqual(self.read_managed_state(), {})
+
     def test_should_keep_the_other_managed_preferences_when_the_schedule_is_incomplete(self):
         link_global_prefs_override(self.data_dir, self.config_dir, {
             'start_hour': '22:00',

--- a/boinc/operator/test/test_global_prefs_override.py
+++ b/boinc/operator/test/test_global_prefs_override.py
@@ -91,23 +91,59 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
         self.assertEqual(self.read_preferences(self.global_prefs_override),
                          '<global_preferences>\n  <niu_max_ncpus_pct>50</niu_max_ncpus_pct>\n  <niu_cpu_usage_limit>75.0</niu_cpu_usage_limit>\n</global_preferences>')
 
+    def test_should_ignore_a_start_hour_without_an_end_hour(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '22:00'})
+
+        # BOINC would default the missing end_hour to midnight, silently computing 22:00 -> 00:00.
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n</global_preferences>')
+        self.assertEqual(self.read_managed_state(), {})
+
+    def test_should_ignore_an_end_hour_without_a_start_hour(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {'end_hour': '08:00'})
+
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n</global_preferences>')
+        self.assertEqual(self.read_managed_state(), {})
+
+    def test_should_keep_the_other_managed_preferences_when_the_schedule_is_incomplete(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {
+            'start_hour': '22:00',
+            'max_ncpus': 50
+        })
+
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n  <niu_max_ncpus_pct>50</niu_max_ncpus_pct>\n</global_preferences>')
+
+    def test_should_withdraw_a_window_it_wrote_when_the_schedule_becomes_incomplete(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {
+            'start_hour': '22:00',
+            'end_hour': '08:00'
+        })
+
+        link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '22:00'})
+
+        # Half a window is worse than none: BOINC would keep the old end_hour otherwise.
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n</global_preferences>')
+
     def test_should_keep_preferences_set_outside_the_add_on(self):
         self.write_preferences(self.global_prefs_override,
                                '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
 
-        link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '00:35'})
+        link_global_prefs_override(self.data_dir, self.config_dir, {'max_ncpus': 50})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n  <start_hour>0.35</start_hour>\n</global_preferences>')
+                         '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n  <niu_max_ncpus_pct>50</niu_max_ncpus_pct>\n</global_preferences>')
 
     def test_should_update_a_managed_preference_in_place(self):
         self.write_preferences(self.global_prefs_override,
                                '<global_preferences>\n  <start_hour>22.0</start_hour>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
 
-        link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '00:35'})
+        link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '00:35', 'end_hour': '08:59'})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <start_hour>0.35</start_hour>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
+                         '<global_preferences>\n  <start_hour>0.35</start_hour>\n  <disk_max_used_gb>100</disk_max_used_gb>\n  <end_hour>8.59</end_hour>\n</global_preferences>')
 
     def test_should_remove_a_managed_preference_it_wrote_when_its_option_is_gone(self):
         self.write_managed_state({'start_hour': 22.0})
@@ -132,28 +168,28 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
     def test_should_not_recreate_the_config_file_through_a_broken_symlink(self):
         os.symlink(self.configured_global_prefs_override, self.global_prefs_override)
 
-        link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '00:35'})
+        link_global_prefs_override(self.data_dir, self.config_dir, {'max_ncpus': 50})
 
         self.assertFalse(os.path.exists(self.configured_global_prefs_override))
         self.assertFalse(os.path.islink(self.global_prefs_override))
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <start_hour>0.35</start_hour>\n</global_preferences>')
+                         '<global_preferences>\n  <niu_max_ncpus_pct>50</niu_max_ncpus_pct>\n</global_preferences>')
 
     def test_should_regenerate_an_unparseable_global_prefs_override(self):
         self.write_preferences(self.global_prefs_override, '<global_preferences>\n  <start_hour>0.35')
 
-        link_global_prefs_override(self.data_dir, self.config_dir, {'end_hour': '08:59'})
+        link_global_prefs_override(self.data_dir, self.config_dir, {'cpu_usage_limit': 75.0})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <end_hour>8.59</end_hour>\n</global_preferences>')
+                         '<global_preferences>\n  <niu_cpu_usage_limit>75.0</niu_cpu_usage_limit>\n</global_preferences>')
 
     def test_should_regenerate_a_global_prefs_override_with_an_unexpected_root(self):
         self.write_preferences(self.global_prefs_override, '<cc_config>\n  <log_flags></log_flags>\n</cc_config>')
 
-        link_global_prefs_override(self.data_dir, self.config_dir, {'end_hour': '08:59'})
+        link_global_prefs_override(self.data_dir, self.config_dir, {'cpu_usage_limit': 75.0})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <end_hour>8.59</end_hour>\n</global_preferences>')
+                         '<global_preferences>\n  <niu_cpu_usage_limit>75.0</niu_cpu_usage_limit>\n</global_preferences>')
 
     def test_should_ignore_an_unreadable_managed_state(self):
         self.write_preferences(f'{self.data_dir}/{MANAGED_STATE_FILE}', 'not json')


### PR DESCRIPTION
Stacked on #122 (which is stacked on #121). Base is `fix/gui-rpc-auth-default`, so the diff here is only this fix; GitHub retargets as the stack merges.

## Problem

`start_hour` and `end_hour` are documented as a pair (`DOCS.md`: "Must be used together with `start_hour`"), but nothing enforced it. The operator wrote whichever option was set and BOINC filled the missing one with its own default of 0 — midnight. Measured against a live client with `boinccmd --get_cc_status` at 09:02 UTC:

| options | effective window | status at 09:02 |
|---|---|---|
| neither | always | `suspended: CPU is busy` (no time restriction) |
| `start_hour: 22:00` alone | **22:00 → 00:00** | `suspended: time of day` |
| `start_hour: 08:00` alone | **08:00 → 00:00** | no time-of-day suspension |
| `end_hour: 20:00` alone | **00:00 → 20:00** | no time-of-day suspension |

So someone setting only `start_hour: 22:00`, meaning "compute from 22:00 onwards", got computing that **stopped at midnight** — no error, no warning in the log, nothing visible in the Supervisor UI.

## Fix

When exactly one of the two is set, the operator logs a warning and writes neither, so BOINC computes all the time — which is what an unset schedule already means and what the docs already promised.

Deliberately **not** a startup failure: a soft config mistake should not crash-loop the app now that exit codes propagate (3.8.0). Say the word if you'd rather it hard-fail and surface in Supervisor instead.

It composes with the three-way merge from 3.8.1: a window the operator previously wrote is *withdrawn* when the config becomes incomplete, rather than leaving half of it behind.

HA's option schema has no cross-field validation, so the operator is the only place this can live.

## Verification

45 unit tests pass — 4 new here, and 5 existing ones updated because they had used a lone hour as a convenient fixture, which the new rule correctly ignores.

Against the real image at 09:51 UTC:

```
start_hour 22:00 alone     warning=1   suspended: CPU is busy      ← no time window, as intended
start 22:00 + end 07:00    warning=0   suspended: time of day      ← window still works
```

Before this change the first row read `suspended: time of day`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP