### PR TITLE
fix(boinc): stop when the account manager is only partially configured

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -411,6 +411,51 @@ presentation pages, fetched 2026-08-08). Ordered roughly by impact.
 - `boinctui` has no `translations/` dir, but its `config.yaml` declares no `schema:` at all, so
   there is nothing to translate. Not a gap.
 
+## Config schema — breaking redesign, for a future major
+
+- [ ] **Collapse `start_hour` + `end_hour` into a single `computing_window` option.** Breaking
+  change to the option schema, so it belongs in the next major (`4.0.0`), not a patch.
+
+  **Why.** There are three tiers of configuration validation available here, and only the first
+  one is visible to a user who does not read logs:
+
+  1. *The schema.* An option without `?` is required, and a value that fails its `match(...)` is
+     rejected by Supervisor **before the container starts**, with the error surfaced in the UI.
+  2. *A runtime hard failure.* `bashio::exit.nok` in the official add-ons, `sys.exit(1)` here.
+     Measured on a running Supervisor (2026-08-09): with the Watchdog toggle off — the default —
+     the app just reports `state: stopped`, indistinguishable from a stop the user asked for.
+     With Watchdog on it becomes a restart loop. Either way the explanation is only in the log.
+  3. *Degrade and warn.* A log line, nothing more.
+
+  The schedule bugs fixed in 3.8.3 (half a window, and an equal pair) can only be caught at
+  tier 3 today, because HA's option schema validates field by field and cannot express "these two
+  go together". A single string makes the illegal state unrepresentable, moving the whole class up
+  to tier 1:
+
+  ```yaml
+  computing_window: "match(^(?:[01]\\d|2[0-3]):[0-5]\\d-(?:[01]\\d|2[0-3]):[0-5]\\d$)?"
+  ```
+
+  **What it does not fix.** `22:00-22:00` still matches that regex, and BOINC reads an equal pair
+  as no restriction at all. The runtime check from 3.8.3 has to stay; only the half-window class
+  disappears.
+
+  **Migration is the hard part, and the obvious assumption is wrong.** Supervisor does *not*
+  reject an option that is missing from the schema — it drops it and logs a warning nobody reads.
+  Verified by POSTing an unknown option to a running Supervisor:
+
+  ```
+  WARNING [supervisor.apps.options] Option 'computing_window' does not exist in the schema
+    for BOINC (local_boinc)
+  ```
+
+  The add-on then started normally with `options.json` = `{}`. So a straight rename would make
+  every existing user's schedule **silently vanish**, and BOINC would quietly start computing
+  24/7 — the exact failure mode 3.8.3 was written to prevent, reintroduced by the migration.
+  The transition therefore needs at least: keep all three keys in the schema for a full minor
+  release, prefer `computing_window` when set, log a deprecation warning when the old pair is
+  used, and only drop `start_hour`/`end_hour` in the major after that.
+
 ## Config schema — feature gaps vs. upstream BOINC preferences
 
 `boinc/config.yaml:16-27` covers account manager, remote RPC, a computing time window, and two

--- a/TODO.md
+++ b/TODO.md
@@ -674,7 +674,16 @@ adding (each is a `dict2xml` key away, same pattern as `global_prefs_override.py
   functional impact, but it would need a full rewrite — not just re-enabling — before it could
   ever be turned on. Either rewrite it to match the real process tree or delete it so it doesn't
   mislead a future contributor into thinking AppArmor support is closer than it is.
-- [ ] `configure_boinc_projects` (`boinc/operator/boinccmd.py:45-90`) logs a warning and returns
+- [x] **Fixed in `boinc` 3.8.4** — it now logs an error and returns `False`, which `main.py` turns
+  into a stopped client and `sys.exit(1)`. This is the one place in the add-on where the official
+  hard-fail pattern fits: `home-assistant/addons` uses `bashio::exit.nok` in 17 places, and the
+  closest precedent is `zwave_js/rootfs/etc/cont-init.d/config.sh`, which refuses to start when
+  `network_key` and `s0_legacy_key` disagree — *"we are unsure which one to use. One needs to be
+  removed from the configuration in order to start the app"*. Half an account manager is the same
+  shape: no safe reading, and continuing leaves the app looking healthy while contributing to
+  nothing. Contrast with the schedule pair in 3.8.3, which degrades instead precisely because it
+  *does* have a documented safe reading ("if not set, BOINC computes all the time").
+  `configure_boinc_projects` (`boinc/operator/boinccmd.py:45-90`) logs a warning and returns
   `True` (success) when account-manager options are partially set (e.g. URL without
   username/password) — `boinccmd.py:63-64`. That's arguably the right runtime behavior (don't
   tear down a running client over a config typo), but it means an invalid partial config is
@@ -682,3 +691,11 @@ adding (each is a `dict2xml` key away, same pattern as `global_prefs_override.py
   surfacing it as an error in the Supervisor UI. Low priority; noting since it compounds the
   "always exits 0" issue above — there's currently no path from *misconfigured account manager*
   to *visible failure state*.
+
+  Caveat worth knowing, measured on a running Supervisor (2026-08-09): a hard failure is **not**
+  loud. The add-on container runs with Docker restart policy `no`, so with the Watchdog toggle off
+  — the default — the app simply reports `state: stopped`, indistinguishable from a stop the user
+  asked for; the only trace is the log line. With Watchdog on, Supervisor restarts it within five
+  seconds (`Watchdog found app BOINC is stopped, restarting...`), so a permanent config error
+  becomes a restart loop. Exiting non-zero is still the right call here — a silent healthy-looking
+  app that computes nothing is worse — but do not assume the user will see an error in the UI.

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.4
+
+Stop with an error when the account manager is only partially configured, instead of starting and contributing to nothing
+
 ## 3.8.3
 
 Ignore an incomplete computing schedule instead of letting BOINC fill the missing hour with midnight

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -62,6 +62,10 @@ manager at all: an account manager you attached yourself — from the boinctui a
 Manager, or `boinccmd` — is left as it is. Detaching it is done the same way you attached it, for
 example `boinccmd --acct_mgr detach`.
 
+Setting only some of the three is a configuration error and **the app stops with an error in the
+log** rather than starting. Attaching is impossible without all three, and starting anyway would
+leave the app looking healthy while it contributes to nothing at all.
+
 #### Remote Control Options
 
 - **gui_rpc_password** (optional)

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC
-version: "3.8.3"
+version: "3.8.4"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"

--- a/boinc/operator/boinccmd.py
+++ b/boinc/operator/boinccmd.py
@@ -61,7 +61,11 @@ def configure_boinc_projects(data_folder: str, account_manager_url: str | None, 
         current_account_manager_read = True
 
     if any([account_manager_url, account_manager_username, account_manager_password]) and not all([account_manager_url, account_manager_username, account_manager_password]):
-        logging.warning(f'To configure an Account manager the URL, username and password must be all set')
+        # Half an account manager has no safe reading: attaching is impossible, and carrying on
+        # would leave the app looking healthy while contributing to nothing at all. Stop instead,
+        # so the mistake reaches the exit code rather than scrolling past in the log.
+        logging.error(f'Incomplete account manager configuration: account_manager_url, account_manager_username and account_manager_password must all be set, or all be empty')
+        return False
     elif account_manager_url is not None and account_manager_username is not None and account_manager_password is not None:
         if current_account_manager_url is None:
             logging.debug(f'Account manager {account_manager_url} configured but not attached, attaching')

--- a/boinc/operator/boinccmd.py
+++ b/boinc/operator/boinccmd.py
@@ -62,7 +62,7 @@ def configure_boinc_projects(data_folder: str, account_manager_url: str | None, 
 
     if any([account_manager_url, account_manager_username, account_manager_password]) and not all([account_manager_url, account_manager_username, account_manager_password]):
         # Half an account manager has no safe reading: attaching is impossible, and carrying on
-        # would leave the app looking healthy while contributing to nothing at all. Stop instead,
+        # would leave the add-on looking healthy while contributing to nothing at all. Stop instead,
         # so the mistake reaches the exit code rather than scrolling past in the log.
         logging.error(f'Incomplete account manager configuration: account_manager_url, account_manager_username and account_manager_password must all be set, or all be empty')
         return False

--- a/boinc/operator/test/test_boinccmd.py
+++ b/boinc/operator/test/test_boinccmd.py
@@ -89,6 +89,8 @@ class ConfigureBoincProjectsTestCase(unittest.TestCase):
 
         self.assertFalse(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, None))
 
+        self.assertEqual(executed_commands(run), [['--acct_mgr', 'info']])
+
     @patch('boinccmd.subprocess.run')
     def test_should_fail_an_incomplete_account_manager_without_detaching_the_attached_one(self, run):
         run.return_value = account_manager_info(ACCOUNT_MANAGER_URL)

--- a/boinc/operator/test/test_boinccmd.py
+++ b/boinc/operator/test/test_boinccmd.py
@@ -74,10 +74,26 @@ class ConfigureBoincProjectsTestCase(unittest.TestCase):
         ])
 
     @patch('boinccmd.subprocess.run')
-    def test_should_not_configure_a_partially_configured_account_manager(self, run):
+    def test_should_fail_when_only_the_account_manager_url_is_configured(self, run):
         run.return_value = account_manager_info(None)
 
-        self.assertTrue(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, None, None))
+        # Half an account manager cannot be attached, and a warning would let the app look healthy
+        # while contributing to nothing.
+        self.assertFalse(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, None, None))
+
+        self.assertEqual(executed_commands(run), [['--acct_mgr', 'info']])
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_fail_when_the_account_manager_password_is_missing(self, run):
+        run.return_value = account_manager_info(None)
+
+        self.assertFalse(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, None))
+
+    @patch('boinccmd.subprocess.run')
+    def test_should_fail_an_incomplete_account_manager_without_detaching_the_attached_one(self, run):
+        run.return_value = account_manager_info(ACCOUNT_MANAGER_URL)
+
+        self.assertFalse(configure_boinc_projects('a data folder', None, ACCOUNT_MANAGER_USERNAME, None))
 
         self.assertEqual(executed_commands(run), [['--acct_mgr', 'info']])
 


### PR DESCRIPTION
Stacked on #123. Base is `fix/schedule-pair`; GitHub retargets as the stack merges.

## Problem

`configure_boinc_projects` logged a warning and returned `True` when only some of `account_manager_url` / `account_manager_username` / `account_manager_password` were set. The app started, attached to nothing, computed nothing, and reported itself healthy — re-warning on every restart, with nothing surfacing anywhere.

## Fix

It now logs an error and returns `False`, which `main.py` turns into a stopped BOINC client and `sys.exit(1)`.

This is the one place in the add-on where the hard-fail pattern fits. `home-assistant/addons` uses `bashio::exit.nok` in 17 places, and the closest precedent is `zwave_js`:

```bash
bashio::log.fatal "Both 'network_key' and 's0_legacy_key' are set to different values "
bashio::log.fatal "so we are unsure which one to use. One needs to be removed from the "
bashio::log.fatal "configuration in order to start the app."
bashio::exit.nok
```

Half an account manager is the same shape — no safe reading, and continuing hides the problem. It deliberately differs from the schedule pair in #123, which degrades instead, precisely because that one *does* have a documented safe reading ("if not set, BOINC computes all the time").

## Verification

48 unit tests pass; the partial-config case went from one test asserting `True` to three asserting `False`, including one checking that an account manager attached outside the options is not detached on the way out.

End to end against the real image:

```
url alone                              exit=1  ERROR Incomplete account manager configuration: ...
                                               ERROR BOINC Add-on Operator stopped: failed to configure BOINC projects
url + username, no password            exit=1  (same)
empty configuration                    exit=0  no errors
operator/options.json (what CI runs)   exit=0  no errors
```

## One caveat, measured on a running Supervisor

A hard failure is **not** loud, and this is worth knowing before applying the pattern more widely. Add-on containers run with Docker restart policy `no`, so with the Watchdog toggle off — the default — the app just reports `state: stopped`, indistinguishable from a stop the user asked for; the only trace is the log line. With Watchdog on, Supervisor restarts it within five seconds (`Watchdog found app BOINC is stopped, restarting...`), so a permanent config error becomes a restart loop.

Exiting non-zero is still right here — a silent healthy-looking app that computes nothing is worse than a stopped one — but do not expect the user to see an error in the UI. Recorded in `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP