### PR TITLE
docs: rewrite user-facing docs, changelog, and translations in end-user language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,3 +137,12 @@ editing files outside a changed add-on's directory does not trigger its pipeline
   `config.yaml`/directory names/internal code still say "addon"/"add-on".
 - When Claude Code creates a commit in this repo, use an `Assisted-by:` trailer instead of the
   default `Co-Authored-By:` trailer.
+- Everything Home Assistant shows on an app's page is end-user documentation: `DOCS.md`
+  (Documentation tab), `CHANGELOG.md` (Changelog tab and the GitHub Release body) and
+  `translations/*.yaml` (the text under each field in the Configuration tab). The reader is
+  configuring an app in a UI, not reading code: write what to set, what happens if you set it
+  wrong, and where to see it. Keep out internal filenames, container paths, permissions, exit
+  codes, and BOINC/operator implementation details; that reasoning belongs in `TODO.md`, code
+  comments, or the PR description. Never point a user at a file or command they can't reach from
+  the Home Assistant UI, the File editor add-on, or Samba. When an option's behavior changes,
+  update its text in `translations/` too.

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -2,43 +2,43 @@
 
 ## 3.8.4
 
-Stop with an error when the account manager is only partially configured, instead of starting and contributing to nothing
+Stop the app with an error, visible in the Log tab, when only some of the three account manager options are set
 
 ## 3.8.3
 
-Ignore an incomplete computing schedule instead of letting BOINC fill the missing hour with midnight
+Ignore an incomplete computing schedule instead of silently starting it at midnight
 
-Ignore a computing schedule whose start and end hours are equal, which BOINC reads as no restriction
+Ignore a computing schedule whose start and end hours are equal, since BOINC treats that as no restriction at all
 
 ## 3.8.2
 
-Let the BOINC client generate its own GUI RPC password when none is configured, instead of writing an empty one
+Let the BOINC client generate its own GUI RPC password when none is configured, instead of leaving it blank
 
-Write gui_rpc_auth.cfg with 0600 permissions, like the BOINC client does, and restrict an existing one written by an older version
+Restrict access to the file that stores the GUI RPC password, matching what the BOINC client itself does, including one written by an older version of the app
 
-Stop writing the GUI RPC password through a symlinked gui_rpc_auth.cfg, which would put it outside the data folder
+Guarantee the GUI RPC password is always written inside the app's own data, never followed out through a symlink
 
 ## 3.8.1
 
-Keep preferences set from boinctui or a remote BOINC Manager instead of overwriting global_prefs_override.xml on every start
+Keep preferences set from boinctui or a remote BOINC Manager instead of resetting them on every restart
 
-Stop recreating a deleted global_prefs_override.xml in the config folder through a stale symlink
+Fix a deleted custom preferences override file being silently recreated, so removing it now works and the app's own scheduling and CPU options apply again
 
-Fix the documented filename for a custom preferences override, which was global_preferences_override.xml
+Fix the documented filename for a custom preferences override, which was wrong
 
 ## 3.8.0
 
-Fix a custom global_prefs_override.xml being overwritten on every start
+Fix a custom preferences override file being overwritten on every start
 
-Keep an account manager attached outside the app options instead of detaching it
+Keep an account manager attached when it was set up outside the app's configuration, instead of detaching it
 
-Exit with a non-zero code when startup fails, so a crash is no longer reported as a clean stop
+Report app startup failures clearly instead of showing them as a normal stop
 
-Redact passwords from the configuration dump written at DEBUG log level
+Stop passwords from appearing in the app's logs
 
-Fix the Spanish translation, which used translated structural keys and never applied
+Fix the Spanish translation not applying
 
-Fix the base image in build.yaml being rejected by Supervisor, which broke building from source
+Fix the app failing to build from source
 
 ## 3.7.0
 

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -6,11 +6,13 @@ The BOINC app, running on your Home Assistant, downloads scientific computing jo
 
 ## ⚠️ Important: Protection Mode
 
-**This app requires Protection Mode to be disabled.**
+**This app requires Protection Mode to be disabled** so it can see CPU usage across your whole
+Home Assistant host and pause BOINC computing whenever other apps need the CPU.
 
-Protection Mode must be turned off because the app needs to monitor system-wide CPU usage across all processes on the host system. This functionality is essential to automatically suspend BOINC computations when other applications need CPU resources, preventing BOINC from interfering with your Home Assistant instance or other critical services.
+To disable it: **Settings → Add-ons → BOINC → Info**, then turn off **Protection mode**.
 
-**Security Note:** Disabling Protection Mode grants the container elevated access to host resources. Only enable this app if you understand and accept the security implications.
+**Security Note:** Disabling Protection Mode grants this app elevated access to host resources.
+Only install it if you understand and accept that.
 
 ## How to use
 
@@ -56,25 +58,24 @@ There is a boinctui app available for this purpose [here](https://github.com/hec
   - Password for the configured user in the BOINC Account Manager
   - Required if `account_manager_url` is set
 
-When these three options are set, the app keeps the BOINC client attached to that account manager,
-replacing a different one if needed. When they are left empty, the app does not touch the account
-manager at all: an account manager you attached yourself — from the boinctui app, a remote BOINC
-Manager, or `boinccmd` — is left as it is. Detaching it is done the same way you attached it, for
-example `boinccmd --acct_mgr detach`.
+Set all three and the app keeps the BOINC client attached to that account manager, replacing a
+different one if needed. Leave all three empty and the app leaves the account manager alone: one
+you attached yourself — from the boinctui app, a remote BOINC Manager, or a command-line tool —
+stays attached. Detach it the same way you attached it.
 
-Setting only some of the three is a configuration error and **the app stops with an error in the
-log** rather than starting. Attaching is impossible without all three, and starting anyway would
-leave the app looking healthy while it contributes to nothing at all.
+**Set only one or two of the three and the app will not start.** Open the app's **Log** tab to see
+why.
 
 #### Remote Control Options
 
 - **gui_rpc_password** (optional)
-  - Define a GUI RPC password to connect remotely
-  - Leave it unset and the BOINC client generates a random password of its own on first start,
-    which you can read from `gui_rpc_auth.cfg` in the BOINC data folder. It stays the same across
-    restarts, so you can copy it into the boinctui app
-  - Set it to an empty string (`gui_rpc_password: ""`) to deliberately use *no* password. Only do
-    this if remote access is off, since it lets any host allowed by `remote_hosts` or
+  - Password required to control this BOINC client remotely, for example from the boinctui app
+  - If you plan to connect from the boinctui app, set a password here and use that same password
+    there
+  - Leave it unset and the client makes up its own private password on first start — Home
+    Assistant gives you no way to see it, so set your own here instead
+  - Set it to an explicit empty string (`gui_rpc_password: ""`) to use *no* password at all. Only
+    do this while remote access is off, since it would let any host allowed by `remote_hosts` or
     `allow_remote_gui_rpc` take full control of the client with no credential
 
 - **remote_hosts** (optional)
@@ -99,14 +100,9 @@ leave the app looking healthy while it contributes to nothing at all.
   - Format: 24-hour time (e.g., `18:00`, `06:00`)
   - Must be used together with `start_hour`
 
-Both hours define a single window and only work as a pair, the same way BOINC Manager always sets
-them together. Setting just one of them, or setting both to the same time, is ignored with a
-warning in the log, and BOINC computes all the time:
-
-- The app does not guess a missing half, because BOINC's own default for it is midnight and that
-  would silently produce a window you never asked for.
-- BOINC reads an equal pair as no restriction at all, so `22:00`–`22:00` is not a 24-hour window;
-  BOINC Manager rejects that combination outright for the same reason.
+Both hours must be set together, or neither. Setting just one of them, or setting both to the same
+time, is ignored — BOINC computes all the time — and a warning explaining why appears in the app's
+**Log** tab.
 
 #### Resource Usage Options
 
@@ -176,10 +172,16 @@ cpu_usage_limit: 75
 
 ### Global Preferences Override
 
-To override the preferences of the BOINC client, a `global_prefs_override.xml` file can be defined in the app config folder: [Preferences Override](https://github.com/BOINC/boinc/wiki/PrefsOverride)
+For full control over BOINC's preferences, you can supply your own `global_prefs_override.xml`
+file — see [Preferences Override](https://github.com/BOINC/boinc/wiki/PrefsOverride) for the
+format. Place it in this app's config folder, which appears as `addon_configs/…_boinc` in the
+File editor and Samba apps.
 
-When that file is present the app uses it as-is, and the `start_hour`, `end_hour`, `max_ncpus` and `cpu_usage_limit` options are ignored.
+When that file is present, the app uses it as-is and the `start_hour`, `end_hour`, `max_ncpus` and
+`cpu_usage_limit` options are ignored.
 
-Otherwise the app writes those four preferences into BOINC's own `global_prefs_override.xml`, and leaves every other preference in that file alone. Anything you set from `boinctui` or a remote BOINC Manager — disk limits, memory, network, work buffer — is preserved across restarts and updates.
-
-Those four preferences follow the options: setting one applies it, and removing it from the options clears it again. A preference the app never wrote is treated as yours and is never removed, so a schedule set from `boinctui` survives even though it uses the same fields.
+Otherwise, the app only manages those four settings. Anything else you set from boinctui or a
+remote BOINC Manager — disk limits, memory, network, work buffer, even a schedule using the same
+start/end time fields — is preserved across restarts and updates. Setting one of the four options
+applies it, and removing it from the options clears it again, without touching preferences you set
+yourself elsewhere.

--- a/boinc/translations/en.yaml
+++ b/boinc/translations/en.yaml
@@ -1,7 +1,7 @@
 configuration:
   gui_rpc_password:
     name: "GUI RPC password"
-    description: "Define a GUI RPC password to connect remotely"
+    description: "Password to control this BOINC client remotely, e.g. from boinctui. Set one if you plan to connect remotely — see the app documentation for what leaving it empty does"
   remote_hosts:
     name: Remote hosts
     description: List of remote hosts to allow remote connection
@@ -10,22 +10,22 @@ configuration:
     description: Allow all remote GUI RPC connections (overrides remote hosts)
   account_manager_url:
     name: Account Manager URL
-    description: "A URL for a BOINC Account Manager, for example: https://scienceunited.org"
+    description: "A URL for a BOINC Account Manager, e.g. https://scienceunited.org. Set all three account manager options together, or leave all three empty — setting only some stops the app from starting"
   account_manager_username:
     name: Account Manager Username
-    description: "A username for a user registered in the BOINC Account Manager"
+    description: "A username for a user registered in the BOINC Account Manager. Required together with the other two account manager options, or the app will not start"
   account_manager_password:
     name: Account Manager Password
-    description: "Password for the configured user in the BOINC Account Manager"
+    description: "Password for the configured user in the BOINC Account Manager. Required together with the other two account manager options, or the app will not start"
   start_hour:
     name: Start Hour
-    description: "Configure the hour when BOINC starts computing"
+    description: "Configure the hour when BOINC starts computing. Must be set together with End Hour; setting only one of them, or setting both to the same time, is ignored"
   end_hour:
     name: End Hour
-    description: "Configure the hour when BOINC stops computing"
+    description: "Configure the hour when BOINC stops computing. Must be set together with Start Hour; setting only one of them, or setting both to the same time, is ignored"
   max_ncpus:
     name: Max CPUs Percentage
-    description: "Maximum number of CPUs to use"
+    description: "Maximum percentage of CPUs to use"
   cpu_usage_limit:
     name: Max CPU Usage Percentage
     description: "Maximum time of usage per CPU"

--- a/boinc/translations/es.yaml
+++ b/boinc/translations/es.yaml
@@ -1,7 +1,7 @@
 configuration:
   gui_rpc_password:
     name: "Contraseña GUI RPC"
-    description: "Definir una contraseña GUI RPC para conectarse de forma remota"
+    description: "Contraseña para controlar este cliente BOINC de forma remota, por ejemplo desde boinctui. Configúrala si vas a conectarte de forma remota — consulta la documentación de la app para saber qué ocurre si la dejas vacía"
   remote_hosts:
     name: Hosts remotos
     description: Lista de hosts remotos para permitir la conexión remota
@@ -10,22 +10,22 @@ configuration:
     description: Permitir todas las conexiones GUI RPC remotas (Anula los hosts remotos)
   account_manager_url:
     name: URL del Gestor de Cuentas
-    description: "URL de un Gestor de Cuentas BOINC, por ejemplo: https://scienceunited.org"
+    description: "URL de un Gestor de Cuentas BOINC, por ejemplo https://scienceunited.org. Configura las tres opciones del Gestor de Cuentas a la vez, o ninguna: si solo configuras algunas, la app no arranca"
   account_manager_username:
     name: Nombre de Usuario del Gestor de Cuentas
-    description: "Nombre de usuario registrado en el Gestor de Cuentas BOINC"
+    description: "Nombre de usuario registrado en el Gestor de Cuentas BOINC. Obligatorio junto con las otras dos opciones del Gestor de Cuentas, o la app no arrancará"
   account_manager_password:
     name: Contraseña del Gestor de Cuentas
-    description: "Contraseña del usuario configurado en el Gestor de Cuentas BOINC"
+    description: "Contraseña del usuario configurado en el Gestor de Cuentas BOINC. Obligatoria junto con las otras dos opciones del Gestor de Cuentas, o la app no arrancará"
   start_hour:
     name: Hora de Inicio
-    description: "Hora en que BOINC comienza a computar"
+    description: "Hora en que BOINC comienza a computar. Debe configurarse junto con Hora de Fin; si solo se pone una, o si ambas son iguales, se ignora"
   end_hour:
     name: Hora de Fin
-    description: "Hora en que BOINC deja de computar"
+    description: "Hora en que BOINC deja de computar. Debe configurarse junto con Hora de Inicio; si solo se pone una, o si ambas son iguales, se ignora"
   max_ncpus:
     name: Porcentaje Máximo de CPUs
-    description: "Número máximo de CPUs a utilizar"
+    description: "Porcentaje máximo de CPUs a utilizar"
   cpu_usage_limit:
     name: Porcentaje Máximo de Uso de CPU
     description: "Tiempo máximo de uso por CPU"

--- a/boinctui/CHANGELOG.md
+++ b/boinctui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.1
 
-Fix the base image in build.yaml being rejected by Supervisor, which broke building from source
+Fix the app failing to build from source
 
 ## 2.4.0
 

--- a/boinctui/DOCS.md
+++ b/boinctui/DOCS.md
@@ -4,12 +4,18 @@
 
 ### Connecting to the BOINC App
 
-To connect to the BOINC app, use the hostname shown on the app info page in Home Assistant.
+Do this first, in the **BOINC app's** configuration:
 
-Make sure to allow remote GUI RPC connections in your BOINC client settings. You need to add the boinctui app's hostname as a permitted remote host to enable the connection.
+1. Allow the connection: either turn on `allow_remote_gui_rpc`, or add this app's hostname (shown
+   on this app's Info page in Home Assistant) to `remote_hosts`.
+2. Set `gui_rpc_password` to a password of your choice.
+
+Then, in boinctui, connect using the BOINC app's hostname (shown on its Info page) and the
+password from step 2.
 
 ### Connecting to Other BOINC Clients
 
-To connect to other BOINC clients, you need to know their hostnames and ensure that they allow remote GUI RPC connections.
+To connect to other BOINC clients, you need their hostname, and they need to allow remote GUI RPC
+connections the same way.
 
 See: [BOINC Remote Control Documentation](https://boinc.berkeley.edu/wiki/Controlling_BOINC_remotely)


### PR DESCRIPTION
## Summary

Everything Home Assistant renders on an app's page — `DOCS.md` (Documentation tab), `CHANGELOG.md` (Changelog tab, and the GitHub Release body extracted by `release.yaml`), and `translations/*.yaml` (the field descriptions on the Configuration tab) — is end-user documentation. The reader is configuring an app in a UI, not reading code or a PR diff. The 3.8.0–3.8.4 fixes left review-era language in all three: internal filenames, octal file permissions, exit codes, symlink/data-folder mechanics, and paragraphs justifying *why* something is implemented a certain way. None of that helps someone deciding what to type into a field.

This PR rewrites those three surfaces (plus adds the convention to `CLAUDE.md` so it doesn't regress) around one question: **what do I set, what happens if I set it wrong, and where do I see it.** No version bump — Supervisor serves `DOCS.md`/`CHANGELOG.md`/`translations/` from the cloned repo, not the image, and `find-changed-addons` only watches `build.yaml`/`config.yaml`/`Dockerfile`/`operator`, so this ships on the next repo sync without a build or release.

## What moved out (and where it went)

- Implementation rationale ("attaching is impossible without all three, and starting anyway would leave the app looking healthy while it contributes to nothing") → gone; the practical rule ("all three or none, or the app won't start — check the Log tab") stays.
- BOINC Manager's internal preference-mask semantics, midnight defaults → gone; the practical rule ("start/end hour only work as a pair") stays.
- Octal permissions, symlink mechanics, exit codes in `CHANGELOG.md` → reworded to what changed for the user, facts preserved, no new entries added and no already-published GitHub Releases touched.

## A real defect, not just wording

`boinc/DOCS.md` told users to read their auto-generated GUI RPC password from `gui_rpc_auth.cfg` "in the BOINC data folder." `boinc/config.yaml` only maps `addon_config` — the BOINC data folder is not reachable from the File editor, Samba, or anywhere else in the Home Assistant UI. That instruction was unfollowable. Replaced with: set `gui_rpc_password` yourself if you plan to connect from the boinctui app; an unset password is auto-generated and can't be read back; an explicit empty string means no password (only safe with remote access off).

## Changes by file

- **`boinc/DOCS.md`** — click path to disable Protection Mode; account-manager all-or-nothing rule + where the startup failure surfaces; the `gui_rpc_password` fix above; start/end hour pairing rule without the BOINC-internal reasoning; named the actual, reachable config folder (`addon_configs/…_boinc`) for the Global Preferences Override section. `Resource Usage Options` intentionally left byte-identical — a parallel PR changes that section's behavior.
- **`boinctui/DOCS.md`** — replaced the abstract GUI-RPC explanation with the concrete two-app recipe: what to set in the BOINC app (`allow_remote_gui_rpc` or `remote_hosts`, plus `gui_rpc_password`), then what to use when connecting from boinctui.
- **`boinc/CHANGELOG.md`** (3.8.0–3.8.4) and **`boinctui/CHANGELOG.md`** (2.4.1) — reworded to user-visible effect, same facts, no new version entries.
- **`boinc/translations/en.yaml` + `es.yaml`** — filled the most important gap: the Configuration tab never said the three `account_manager_*` options are all-or-nothing, and since 3.8.4 partial configuration prevents the app from starting. Also documents `gui_rpc_password`'s empty-vs-unset behavior, the `start_hour`/`end_hour` pairing, and fixes `max_ncpus`'s self-contradicting name ("Percentage") vs description ("Maximum number of CPUs"). Structural keys (`configuration:`, `name:`, `description:`, `network:`) kept in English in both files, matching what's kept `es.yaml` working since 3.8.0.
- **`CLAUDE.md`** — added this as a standing convention under `## Conventions`.

## Deviations from the plan

None — the plan's PR 1 scope was implemented as specified, including leaving `Resource Usage Options` untouched for the parallel PR.

## Test plan

- [x] `mkdocs build --strict` — builds clean (only pre-existing informational nav-link notices, no warnings/errors)
- [x] `yamllint` on all tracked YAML — zero errors; two pre-existing-style line-length warnings on the two longest new translation strings (line-length is warning-only at 180 per `.yamllint`)
- [ ] Supervisor devcontainer check (Documentation/Changelog/Configuration tabs render correctly and the new text appears without reinstalling or bumping version) — left to the human, per instructions for this task
- [x] Re-read both `DOCS.md` files against the end-user-only bar: no internal filename, container path, permission, exit code, or design rationale remains reachable from the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP