### PR TITLE
test(boinc): fix the race that failed the 3.8.5 release

### DIFF
--- a/boinc/operator/test/test_main.py
+++ b/boinc/operator/test/test_main.py
@@ -20,14 +20,19 @@ FAKE_BOINC = textwrap.dedent("""\
     #!/usr/bin/env bash
     set -u
 
-    touch "$BOINC_MARKER_FILE"
-
     if [ -n "${FAKE_BOINC_EXIT_CODE:-}" ]; then
+        touch "$BOINC_MARKER_FILE"
         exit "$FAKE_BOINC_EXIT_CODE"
     fi
 
     trap 'echo TERM > "$BOINC_SIGNAL_FILE"; exit 0' TERM
     trap 'echo INT > "$BOINC_SIGNAL_FILE"; exit 0' INT
+
+    # Written only once the traps above are armed: the marker is what the tests wait on before
+    # signalling, so it has to mean "this client can record a signal", not merely "it started".
+    # Touching it any earlier leaves a window where a forwarded signal hits bash's default
+    # disposition and the signal file is never written.
+    touch "$BOINC_MARKER_FILE"
 
     while true; do
         sleep 0.05


### PR DESCRIPTION
The Release run for 3.8.5 on `main` **failed**, so no `boinc-v3.8.5` tag and no image were published. The cause is a race in `test_main.py`, introduced in #127 — the operator code itself is fine.

## The race

The fake BOINC client touched its marker file as its very first statement, *before* installing the `TERM` and `INT` traps:

```bash
touch "$BOINC_MARKER_FILE"      # tests wait on this, then signal
...
trap '...' TERM                 # ...but the trap is only armed here
```

The tests wait for that marker before signalling the operator. If the forwarded signal lands in the window between the two, bash applies its default disposition, the fake client dies without writing the signal file, and `read_signal()` raises `FileNotFoundError` — which is exactly what CI reported:

```
ERROR: test_sigterm_is_forwarded_to_the_client
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp46zytph8/boinc-signal'
```

#127 closed the equivalent race on the operator side (the "started" log is emitted only after `signal.signal(...)` runs) but not this one on the client side.

## Verification

Reproduced deterministically before fixing, by inserting `sleep 0.3` between the touch and the traps: **3 of the 5 cases failed** with the same `FileNotFoundError`. With the marker moved after the traps and **the same delay still in place**, all 5 pass — the window is closed, not merely narrowed. The delay was then removed and the full suite run 15 times with no failures.

## Release consequence

This republishes 3.8.5: `config.yaml` already carries that version, 3.8.5 is still ahead of the latest tag (`boinc-v3.8.4`), and the change lives under `boinc/operator/`, which is what `find-changed-addons` diffs. No `CHANGELOG.md` entry — nothing here is visible to a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP