### PR TITLE
ci: stop pull request runs from blocking the documentation deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,10 +14,6 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,6 +42,13 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Scoped to this job, not the whole workflow: pull request runs never deploy, so sharing the
+    # group with them only let them evict main's queued deployment. Newer commits cancel older
+    # deployments instead of queueing behind them, so a deploy that hangs waiting for the
+    # github-pages environment cannot block every later run.
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## The bug

`docs.yaml` declared the `pages` concurrency group at **workflow level**, so `pull_request` runs joined it — even though they never deploy. Both the artifact upload and the `deploy` job are gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`.

GitHub lets only one run *wait* per group. Every pull request run that arrived while main's run was queued cancelled it. The site stopped updating, with no failed run to notice: the evicted runs are `cancelled`, not `failure`.

## The trigger

Run [31315690705](https://github.com/hectorespert/boinc-addons/actions/runs/31315690705) (push, `ca17308`) had its `build` job succeed at 13:23:59 and its `deploy` job sit **queued for seven hours** waiting for the `github-pages` environment. It held the group the whole time, and the fifteen docs runs that followed — including the pushes for #126, #127, #128 and #125 — were cancelled while waiting behind it.

I cancelled that run manually. The queued run for `14f3c72` then picked up and deployed; https://hectorespert.github.io/boinc-addons/boinc/DOCS/ now serves the rewritten docs and the 3.9.0 options.

## The change

Move `concurrency` to the `deploy` job, so only runs that actually deploy contend for it, and switch to `cancel-in-progress: true`.

The [GitHub Pages starter workflow](https://github.com/actions/starter-workflows/blob/main/pages/static.yml) recommends `false` to let production deployments finish. That recommendation is what turned one hung job into a seven-hour outage. For a static docs site only the newest commit matters, so a newer deployment superseding an older one is the desired behaviour and it bounds the blast radius of a hang to a single run.

## Not covered here

Nothing alerts on this. A cancelled run looks the same as a deliberate one, so the next silent Pages failure will also go unnoticed until somebody reads the site. Worth a `TODO.md` item rather than scope creep in this PR.