### PR TITLE
feat(boincui): watch several BOINC machines, one section each

### DIFF
--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.0
+
+You can now watch several BOINC machines at once, each with its own section on the page. Add them under BOINC clients in the Configuration tab
+
+Each machine now says whether it is computing and, when it is not, why — usually the time of day or a busy processor
+
+The table lists the tasks running right now and counts the ones waiting and finished, instead of every task at once
+
+A machine that cannot be reached no longer hides the ones that can
+
+Your previous settings keep working and appear as one machine. Move them to the client list when convenient, since the old fields will be removed later
+
 ## 0.3.0
 
 The page now shows the tasks a BOINC client is running and the projects it is attached to

--- a/boincui/DOCS.md
+++ b/boincui/DOCS.md
@@ -1,49 +1,69 @@
 # Home Assistant BOINC UI App
 
-BOINC UI shows what a BOINC client is doing — its tasks and the projects it is attached to — on a
-page inside Home Assistant. It is **experimental**, and this version can only look: it cannot
-suspend, resume or abort anything yet.
+BOINC UI shows what your BOINC clients are doing — what each machine is computing right now, and the
+projects it is attached to — on a page inside Home Assistant. It is **experimental**, and this
+version can only look: it cannot suspend, resume or abort anything.
 
-## Connecting it to the BOINC app
+## Adding a machine
 
-Two apps have to agree, so there are settings on both sides.
+In this app's Configuration tab, add an entry under **BOINC clients** for each machine you want to
+watch:
 
-**First, in the BOINC app's configuration:**
+- **Address** — the hostname or IP address of the machine running BOINC.
+- **Password** — its GUI RPC password.
+- **Name** — optional, just what to call it on the page.
+- **Port** — leave it empty.
+
+Every machine also has to be told to accept the connection, and that is done on the machine itself,
+not in Home Assistant.
+
+### The BOINC app on this Home Assistant
+
+In the **BOINC app's** configuration:
 
 1. Set `gui_rpc_password` to a password of your choice.
-2. Allow the connection: either turn on `allow_remote_gui_rpc`, or add this app's hostname — shown
-   on **this** app's Info page — to `remote_hosts`.
-3. Restart the BOINC app so the changes take effect.
+2. Either turn on `allow_remote_gui_rpc`, or add this app's hostname — shown on **this** app's Info
+   page — to `remote_hosts`.
+3. Restart the BOINC app.
 
-**Then, in this app's configuration:**
+Then use the hostname from the **BOINC app's** Info page as the address here, and the same password.
 
-1. **BOINC client address** — the hostname shown on the **BOINC app's** Info page.
-2. **BOINC client password** — the same password you set in step 1 above.
-3. **BOINC client port** — leave it empty.
+### A computer elsewhere on your network
 
-Start this app and open it with **Open Web UI**. If you would rather reach it from the Home
-Assistant menu, turn on **Show in sidebar** on this app's page.
+Use its address and the GUI RPC password from its own BOINC installation. That computer has to be
+set up to allow remote connections, which is a BOINC setting on that machine.
 
-## Connecting to BOINC on another machine
+One thing that may trip you up: connections from here leave through Home Assistant's own networking,
+so the remote computer will most likely see **the address of your Home Assistant machine**, not this
+app's. If it refuses the connection, that is the address to put in its list of allowed hosts.
 
-The same fields work for a BOINC client running anywhere else on your network: use its address, and
-the password from its own configuration. That machine also has to be set up to accept remote
-connections, which is a setting in BOINC itself rather than in Home Assistant.
+## Reading the page
+
+Each machine gets its own section, showing whether it is computing and, when it is not, why — being
+outside its allowed hours and the processor being busy are the usual reasons.
+
+The table lists only the tasks running at that moment, which is normally one per processor core. A
+line above it counts the rest: **waiting** are downloaded and queued, **finished** are done and
+waiting to be sent back. To see the full queue, use the **boinctui** app.
+
+Each row shows the project, how far along the task is and when it is due. Hovering over a row shows
+BOINC's own name for the task, which is what you would search for in boinctui.
 
 ## When something is wrong
 
-The page tells you which of the three usual problems it hit:
+Each machine reports its own problem, and the others keep working:
 
-- **No BOINC client is configured** — the address or the password is still empty.
-- **Cannot reach the BOINC client** — the address is wrong, the BOINC app is stopped, or it has not
-  been told to accept connections from this app.
-- **The BOINC client rejected the password** — the two passwords do not match. They have to be
-  identical, and the BOINC app needs a restart after changing its own.
+- **Cannot be reached** — wrong address, BOINC not running there, or it has not been told to accept
+  connections from this app.
+- **Rejected the password** — the passwords do not match. The BOINC app needs a restart after
+  changing its own.
+- **Not fully configured** — that entry is missing its address or password.
 
-The page checks the client once a minute. **Refresh now** asks for a check straight away instead of
-waiting for the next one — the result appears within a few seconds, when the page next reloads.
+The page checks every machine once a minute. **Refresh now** asks for a check straight away instead
+of waiting — the result appears within a few seconds, when the page next reloads.
 
-## What this app cannot do yet
+## Upgrading from an earlier version
 
-Change anything. Suspending a task, resuming it or attaching a project all have to be done from the
-**boinctui** app for now.
+If you configured a single client before this version, it keeps working and appears as one machine.
+Move those settings into the **BOINC clients** list when convenient: the old fields are marked as old
+settings and will stop working in a future version.

--- a/boincui/README.md
+++ b/boincui/README.md
@@ -10,9 +10,9 @@ your browser, as an alternative to the text mode interface the boinctui app prov
 
 ## Status
 
-It opens a page inside Home Assistant showing the tasks a BOINC client is running and the projects
-it is attached to, whether that client is the BOINC app on this machine or one elsewhere on your
-network.
+It opens a page inside Home Assistant showing what each of your BOINC machines is computing and the
+projects it is attached to — the BOINC app on this machine, other computers on your network, or
+both.
 
 This app is **experimental and read-only**: it can show you what BOINC is doing, but not change it.
 Use the **boinctui** app to suspend tasks, attach projects or anything else.

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "0.3.0"
+version: "0.4.0"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"
@@ -10,7 +10,20 @@ init: false
 ingress: true
 panel_icon: mdi:chart-box
 stage: experimental
+# A list-of-dict option cannot be marked optional: Supervisor's check for missing options only
+# honours a trailing "?" on a string, and for a list it looks at the first element, which here is a
+# dict (apps/options.py, _check_missing_options). Without this default an empty configuration fails
+# validation, so neither a fresh install nor an upgrade from 0.3.0 would start.
+options:
+  clients: []
 schema:
+  clients:
+    - name: "str?"
+      host: "str"
+      port: "port?"
+      password: "password"
+  # Replaced by the list above. Kept for one version so that upgrading does not silently discard an
+  # existing configuration: Supervisor drops options that are missing from the schema without asking.
   boinc_host: "str?"
   boinc_port: "port?"
   gui_rpc_password: "password?"

--- a/boincui/server/app.py
+++ b/boincui/server/app.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from flask import Flask, redirect, render_template
 
-from boinc import AuthenticationFailed, BoincError, CannotConnect, NotConfigured, read_state
+from boinc import read_all
 
 # Home Assistant serves this app under /api/hassio_ingress/<token>/ and strips that prefix before
 # forwarding, without telling us what it was: the only headers ingress adds are X-Remote-User-* and
@@ -14,63 +14,67 @@ from boinc import AuthenticationFailed, BoincError, CannotConnect, NotConfigured
 # and out of the panel. test_app.py guards all three of href, action and Location.
 SELF = './'
 
-# The BOINC client's state does not move quickly, and every refresh costs it a connection. The page
-# reloads far more often than this, but it only ever reads the snapshot below.
+# A BOINC client's state does not move quickly, and every refresh costs each machine a connection.
+# The page reloads far more often than this, but it only ever reads the snapshot below.
 REFRESH_SECONDS = 60
 
-ERROR_KINDS = {
-    NotConfigured: 'not_configured',
-    CannotConnect: 'cannot_connect',
-    AuthenticationFailed: 'auth_failed',
-}
+
+def clients_from(options: dict) -> list[dict]:
+    """The machines to poll, accepting the single-client options this add-on used to have.
+
+    Supervisor drops options that are absent from the schema without telling anyone, so removing the
+    old keys outright would silently wipe an existing configuration. They keep working for one
+    version instead.
+    """
+    clients = options.get('clients') or []
+    if clients:
+        return clients
+
+    if options.get('boinc_host') or options.get('gui_rpc_password'):
+        logging.warning(
+            'Using the old single-client options. Move them to the "clients" list in the '
+            'Configuration tab; they will stop working in a future version'
+        )
+        return [{
+            'name': options.get('boinc_host'),
+            'host': options.get('boinc_host'),
+            'port': options.get('boinc_port'),
+            'password': options.get('gui_rpc_password'),
+        }]
+
+    return []
 
 
 class Snapshot:
     """The state the views render.
 
     Views never talk to a BOINC client while handling a request: the refresher below writes here and
-    the views only read. That keeps rendering time independent of how many hosts are configured, and
-    means a host that is switched off cannot stall the page.
+    the views only read. That keeps rendering time independent of how many machines are configured,
+    and means one that is switched off cannot stall the page.
     """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._state: dict | None = None
+        self._machines: list[dict] | None = None
         self._updated: datetime | None = None
-        self._error: str | None = None
-        self._error_kind: str | None = None
 
     def read(self) -> dict:
         with self._lock:
-            return {
-                'state': self._state,
-                'updated': self._updated,
-                'error': self._error,
-                'error_kind': self._error_kind,
-            }
+            return {'machines': self._machines, 'updated': self._updated}
 
-    def store(self, state: dict) -> None:
+    def store(self, machines: list[dict]) -> None:
         with self._lock:
-            self._state = state
+            self._machines = machines
             self._updated = datetime.now(timezone.utc)
-            self._error = self._error_kind = None
-
-    def fail(self, error: BoincError) -> None:
-        # The last good state is deliberately kept: a page showing yesterday's tasks next to "could
-        # not reach the client" is more useful than one that goes blank on a single failed poll.
-        with self._lock:
-            self._updated = datetime.now(timezone.utc)
-            self._error = str(error)
-            self._error_kind = ERROR_KINDS.get(type(error), 'error')
 
 
 class Refresher(threading.Thread):
-    """Polls the BOINC client on its own thread, so requests never wait on the network."""
+    """Polls every configured machine on its own thread, so requests never wait on the network."""
 
     def __init__(self, snapshot: Snapshot, options: dict, stop: threading.Event) -> None:
         super().__init__(name='refresher', daemon=True)
         self._snapshot = snapshot
-        self._options = options
+        self._clients = clients_from(options)
         # Not `self._stop`: threading.Thread already uses that name for a private method, and
         # shadowing it makes join() raise TypeError.
         self._stop_requested = stop
@@ -79,23 +83,18 @@ class Refresher(threading.Thread):
     def request_refresh(self) -> None:
         """Ask for a poll now, and return without waiting for it.
 
-        Running the poll inline would block the request for as long as the BOINC host takes to
-        answer -- up to the connect timeout when it is unreachable -- which is exactly what this
+        Running the poll inline would block the request for as long as the slowest machine takes to
+        answer -- up to the connect timeout when one is unreachable -- which is exactly what this
         class exists to keep out of request handling.
         """
         self._wake.set()
 
     def refresh_once(self) -> None:
-        try:
-            self._snapshot.store(read_state(
-                self._options.get('boinc_host'),
-                self._options.get('boinc_port'),
-                self._options.get('gui_rpc_password'),
-            ))
-            logging.debug('Refreshed state from the BOINC client')
-        except BoincError as error:
-            logging.warning(f'Could not read the BOINC client state: {error}')
-            self._snapshot.fail(error)
+        machines = read_all(self._clients)
+        for machine in machines:
+            if machine['error']:
+                logging.warning(f'{machine["name"]}: {machine["error"]}')
+        self._snapshot.store(machines)
 
     def run(self) -> None:
         while not self._stop_requested.is_set():
@@ -104,10 +103,27 @@ class Refresher(threading.Thread):
             self._wake.wait(REFRESH_SECONDS)
 
 
+def format_due(deadline: datetime | None) -> str:
+    """A deadline as something a person reads, e.g. "in 2 days"."""
+    if deadline is None:
+        return '—'
+
+    # Deadlines arrive as naive datetimes in local time, because that is what the library produces.
+    # `now` is deliberately naive too: mixing an aware datetime in here raises TypeError.
+    seconds = (deadline - datetime.now()).total_seconds()
+    if seconds <= 0:
+        return 'overdue'
+    for size, unit in ((86400, 'day'), (3600, 'hour'), (60, 'minute')):
+        if seconds >= size:
+            count = int(seconds // size)
+            return f'in {count} {unit}{"s" if count > 1 else ""}'
+    return 'in under a minute'
+
+
 def create_app(snapshot: Snapshot | None = None) -> Flask:
     app = Flask(__name__)
     app.config['SNAPSHOT'] = snapshot if snapshot is not None else Snapshot()
-    app.config['REFRESH_SECONDS'] = REFRESH_SECONDS
+    app.jinja_env.filters['due'] = format_due
 
     @app.route('/')
     def index():

--- a/boincui/server/boinc.py
+++ b/boincui/server/boinc.py
@@ -8,15 +8,19 @@ import asyncio
 import logging
 
 from pyboinc import init_rpc_client
+from status import describe_activity
 
 DEFAULT_PORT = 31416
 # BOINC's own client gives up well before this; the point is only that a host which accepts the
 # connection and then says nothing cannot hold the refresher forever.
 TIMEOUT_SECONDS = 30
 
+# `active_task_state` when a task is actually executing (lib/common_defs.h: PROCESS_EXECUTING).
+PROCESS_EXECUTING = 1
+
 
 class BoincError(Exception):
-    """Anything that stopped us reading the client's state, phrased for a user to read."""
+    """Anything that stopped us reading a client's state, phrased for a user to read."""
 
 
 class NotConfigured(BoincError):
@@ -29,6 +33,13 @@ class CannotConnect(BoincError):
 
 class AuthenticationFailed(BoincError):
     pass
+
+
+ERROR_KINDS = {
+    NotConfigured: 'not_configured',
+    CannotConnect: 'cannot_connect',
+    AuthenticationFailed: 'auth_failed',
+}
 
 
 def _as_list(value):
@@ -46,7 +57,58 @@ def _as_list(value):
     return [item if isinstance(item, dict) else vars(item) for item in value]
 
 
-async def _collect(host: str, port: int, password: str):
+def _url(value) -> str:
+    """A project URL as text.
+
+    The library parses every `project_url` into one of its own objects, which renders as the URL by
+    accident of `__str__`. Joining tasks to projects needs a real string.
+    """
+    return '' if value is None else str(value)
+
+
+def describe_client(client: dict) -> str:
+    return client.get('name') or client.get('host') or 'BOINC client'
+
+
+def _summarise(results: list, projects: list) -> dict:
+    """Turn raw replies into what the page shows: the running tasks, and counts for the rest."""
+    names = {_url(project.get('master_url')): project.get('project_name') for project in projects}
+
+    running, queued, ready = [], 0, 0
+    for result in results:
+        url = _url(result.get('project_url'))
+        active = result.get('active_task') or {}
+        if active.get('active_task_state') == PROCESS_EXECUTING:
+            running.append({
+                # Kept for the row's `title`: BOINC's own identifiers say nothing to a reader, but
+                # they are what you would search for in boinctui.
+                'name': result.get('name'),
+                'project': names.get(url) or url,
+                'fraction_done': active.get('fraction_done'),
+                'deadline': result.get('report_deadline'),
+            })
+        elif result.get('ready_to_report'):
+            ready += 1
+        else:
+            queued += 1
+
+    # Sorted by deadline, soonest first; anything without one goes last rather than breaking the
+    # comparison. Deadlines are naive datetimes -- never compare them with an aware one.
+    running.sort(key=lambda task: (task['deadline'] is None, task['deadline']))
+
+    return {
+        'running': running,
+        'queued': queued,
+        'ready_to_report': ready,
+        'projects': [
+            {'name': project.get('project_name') or _url(project.get('master_url')),
+             'url': _url(project.get('master_url'))}
+            for project in projects
+        ],
+    }
+
+
+async def _collect(host: str, port: int, password: str) -> dict:
     client = await init_rpc_client(host, password, port)
     try:
         # init_rpc_client connects but does not authenticate, and the query methods below do not
@@ -55,29 +117,56 @@ async def _collect(host: str, port: int, password: str):
         # the page can explain instead of a silently empty screen.
         if not await client.authorize():
             raise AuthenticationFailed('The BOINC client rejected the password')
-        return {
-            'cc_status': await client.get_cc_status(),
-            'projects': _as_list(await client.get_project_status()),
-            'results': _as_list(await client.get_results()),
-        }
+        cc_status = await client.get_cc_status()
+        projects = _as_list(await client.get_project_status())
+        results = _as_list(await client.get_results())
     finally:
         await client.close()
 
+    return {'activity': describe_activity(cc_status), **_summarise(results, projects)}
 
-def read_state(host: str | None, port: int | None, password: str | None) -> dict:
-    """Connect, read the client's state and disconnect. Raises BoincError with a readable message."""
+
+async def _collect_safely(client: dict) -> dict:
+    host, password = client.get('host'), client.get('password')
+    port = client.get('port') or DEFAULT_PORT
     if not host or not password:
-        raise NotConfigured('No BOINC client has been configured yet')
+        return {'error': NotConfigured('This client is missing an address or a password')}
 
-    port = port or DEFAULT_PORT
-    logging.debug(f'Reading state from {host}:{port}')
     try:
-        return asyncio.run(asyncio.wait_for(_collect(host, port, password), TIMEOUT_SECONDS))
-    except AuthenticationFailed:
-        raise
+        logging.debug(f'Reading state from {host}:{port}')
+        state = await asyncio.wait_for(_collect(host, port, password), TIMEOUT_SECONDS)
+        return {'state': state}
+    except AuthenticationFailed as error:
+        return {'error': error}
     except (TimeoutError, OSError, ConnectionError) as error:
-        raise CannotConnect(f'Could not reach a BOINC client at {host}:{port}') from error
+        return {'error': CannotConnect(f'Could not reach a BOINC client at {host}:{port}')}
     except Exception as error:
-        # The library raises bare Exceptions and assertion-style errors on malformed replies, so
-        # anything unexpected still has to reach the page as a message rather than kill the thread.
-        raise BoincError(f'Unexpected reply from the BOINC client at {host}:{port}') from error
+        # The library raises bare exceptions and assertion-style errors on malformed replies, so
+        # anything unexpected still has to reach the page as a message rather than kill the poll.
+        logging.debug(f'Unexpected failure reading {host}:{port}: {error!r}')
+        return {'error': BoincError(f'Unexpected reply from the BOINC client at {host}:{port}')}
+
+
+async def _read_all(clients: list[dict]) -> list[dict]:
+    # Every client is contacted at the same time, so a machine that is switched off delays only
+    # itself: a cycle takes as long as the slowest one rather than the sum of all of them.
+    return await asyncio.gather(*(_collect_safely(client) for client in clients))
+
+
+def read_all(clients: list[dict]) -> list[dict]:
+    """Read every configured client. A failure is reported per client, never raised."""
+    if not clients:
+        return []
+
+    outcomes = asyncio.run(_read_all(clients))
+    machines = []
+    for client, outcome in zip(clients, outcomes):
+        error = outcome.get('error')
+        machines.append({
+            'name': describe_client(client),
+            'host': client.get('host'),
+            'state': outcome.get('state'),
+            'error': str(error) if error else None,
+            'error_kind': ERROR_KINDS.get(type(error), 'error') if error else None,
+        })
+    return machines

--- a/boincui/server/status.py
+++ b/boincui/server/status.py
@@ -1,0 +1,58 @@
+"""How a BOINC client describes what it is doing, translated for someone who is not running one.
+
+The tables come from the client's own source so the wording matches what BOINC says about itself:
+`suspend_reason_string()` and `run_mode_string()` in `lib/str_util.cpp`, and the constants in
+`lib/common_defs.h`.
+"""
+
+# BOINC looks these up with an exact `switch`, not bit tests, and that is deliberate: the values
+# look like flags up to 4096, but 4097 onwards are sequential and would collide with combinations
+# (4097 == 4096 | 1). Matching on the exact value is the only correct reading.
+SUSPEND_REASONS = {
+    1: 'the computer is on battery power',
+    2: 'the computer is in use',
+    4: 'someone asked it to stop',
+    8: 'the time of day is outside its schedule',
+    16: 'it is measuring the computer speed',
+    32: 'it has run out of the disk space it is allowed',
+    128: 'nobody has used the computer recently',
+    256: 'it has just started and is waiting a moment',
+    512: 'a program it was told to avoid is running',
+    1024: 'the processor is busy with something else',
+    2048: 'it has used up its network allowance',
+    4096: 'the operating system asked it to stop',
+    4097: 'the computer is not on WiFi',
+    4098: 'the battery is low',
+    4099: 'the battery is too hot',
+    4100: 'no BOINC window is open',
+    4101: 'Podman is starting up',
+    4102: 'it is waiting for the battery to charge',
+    4103: 'it is waiting for the battery to cool down',
+}
+
+# 64 (CPU throttle) is missing on purpose: the client never reports it, as its own header notes.
+
+RUN_MODE_ALWAYS = 1
+RUN_MODE_AUTO = 2
+RUN_MODE_NEVER = 3
+
+RUN_MODES = {
+    RUN_MODE_ALWAYS: 'always computing',
+    RUN_MODE_AUTO: 'computing when its settings allow',
+    RUN_MODE_NEVER: 'set never to compute',
+}
+
+
+def describe_activity(cc_status: dict | None) -> str:
+    """One line saying whether the client is computing, and if not, why not."""
+    if not cc_status:
+        return 'Unknown'
+
+    mode = cc_status.get('task_mode')
+    reason = cc_status.get('task_suspend_reason') or 0
+
+    if reason:
+        return f'Paused — {SUSPEND_REASONS.get(reason, "BOINC did not say why")}'
+    if mode == RUN_MODE_NEVER:
+        return 'Paused — set never to compute'
+    return f'Computing — {RUN_MODES.get(mode, "running")}'

--- a/boincui/server/templates/index.html
+++ b/boincui/server/templates/index.html
@@ -13,23 +13,32 @@
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     line-height: 1.5;
     margin: 0 auto;
-    max-width: 52rem;
+    max-width: 48rem;
     padding: 1.5rem 1rem;
   }
   h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
-  h2 { font-size: 1.1rem; margin: 1.75rem 0 0.5rem; }
   .muted { opacity: 0.7; font-size: 0.9rem; }
+  .machine {
+    border-left: 3px solid currentColor;
+    margin: 1.75rem 0;
+    padding-left: 0.9rem;
+  }
+  .machine.problem { opacity: 0.85; }
+  .machine h2 { font-size: 1.15rem; margin: 0; }
+  .status { margin: 0.15rem 0; }
+  .counts { font-size: 0.9rem; opacity: 0.75; margin: 0.15rem 0 0.75rem; }
   .card {
     border: 1px solid currentColor;
     border-radius: 0.5rem;
     margin: 1.25rem 0;
     padding: 1rem 1.25rem;
   }
-  .card.problem { border-width: 2px; }
   table { border-collapse: collapse; width: 100%; }
-  th, td { text-align: left; padding: 0.35rem 0.6rem 0.35rem 0; vertical-align: baseline; }
-  th { font-weight: 600; border-bottom: 1px solid currentColor; }
-  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  th, td { text-align: left; padding: 0.3rem 0.6rem 0.3rem 0; vertical-align: baseline; }
+  th { font-weight: 600; border-bottom: 1px solid currentColor; font-size: 0.85rem; }
+  td.due { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  progress { width: 100%; max-width: 8rem; vertical-align: middle; }
+  .pct { font-variant-numeric: tabular-nums; font-size: 0.9rem; }
   button {
     border: 1px solid currentColor;
     border-radius: 0.375rem;
@@ -43,90 +52,88 @@
 </head>
 <body>
 <h1>BOINC UI</h1>
-<p class="muted">Experimental. Shows what the BOINC client is doing; it cannot change anything yet.</p>
+<p class="muted">Experimental. Shows what your BOINC clients are doing; it cannot change anything.</p>
 
-{% if error_kind == 'not_configured' %}
-<div class="card problem">
-  <p><strong>No BOINC client is configured.</strong></p>
-  <p>Open this app's Configuration tab and fill in the address of the machine running BOINC and its
-  GUI RPC password.</p>
-  <p>The BOINC app has to allow the connection as well: give it a GUI RPC password, and either turn
-  on remote access or list this app's hostname among its allowed hosts. Its Documentation tab has
-  the details.</p>
-</div>
-
-{% elif error_kind == 'cannot_connect' %}
-<div class="card problem">
-  <p><strong>Cannot reach the BOINC client.</strong></p>
-  <p>{{ error }}</p>
-  <p>Check that the address in the Configuration tab matches the hostname on the BOINC app's own
-  page, that the BOINC app is started, and that it is allowed to accept connections from this app.</p>
-</div>
-
-{% elif error_kind == 'auth_failed' %}
-<div class="card problem">
-  <p><strong>The BOINC client rejected the password.</strong></p>
-  <p>The GUI RPC password here has to be exactly the one set in the BOINC app's configuration.</p>
-</div>
-
-{% elif error_kind %}
-<div class="card problem">
-  <p><strong>Something went wrong talking to the BOINC client.</strong></p>
-  <p>{{ error }}</p>
-</div>
-
-{% elif not state %}
+{% if machines is none %}
 <div class="card">
-  <p>Checking the BOINC client…</p>
+  <p>Checking your BOINC clients…</p>
   <p class="muted">This page will fill in on its own once the first check finishes.</p>
 </div>
-{% endif %}
 
-{% if state %}
-  {% set tasks = state.results %}
-  <h2>Tasks</h2>
-  {% if tasks %}
-  <table>
-    <thead>
-      <tr><th>Task</th><th>Project</th><th>Progress</th><th>State</th></tr>
-    </thead>
-    <tbody>
-      {% for task in tasks %}
-      <tr>
-        <td>{{ task.name }}</td>
-        <td>{{ task.project_url }}</td>
-        <td class="num">
-          {% if task.active_task and task.active_task.fraction_done is not none %}
-          {{ '%.0f' | format(task.active_task.fraction_done * 100) }}%
-          {% else %}—{% endif %}
-        </td>
-        <td>{% if task.active_task %}Running{% else %}Waiting{% endif %}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% else %}
-  <p>No tasks. The client has nothing to compute right now.</p>
-  {% endif %}
+{% elif not machines %}
+<div class="card">
+  <p><strong>No BOINC client is configured.</strong></p>
+  <p>Open this app's Configuration tab and add a client: the address of the machine running BOINC
+  and its GUI RPC password.</p>
+  <p>That machine has to allow the connection as well. For the BOINC app on this Home Assistant,
+  give it a GUI RPC password and either turn on remote access or list this app's hostname among its
+  allowed hosts; its Documentation tab has the details.</p>
+</div>
 
-  <h2>Projects</h2>
-  {% if state.projects %}
-  <table>
-    <thead>
-      <tr><th>Project</th><th>Address</th></tr>
-    </thead>
-    <tbody>
-      {% for project in state.projects %}
-      <tr>
-        <td>{{ project.project_name or project.master_url }}</td>
-        <td>{{ project.master_url }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% else %}
-  <p>This client is not attached to any project yet.</p>
-  {% endif %}
+{% else %}
+  {% for machine in machines %}
+  <div class="machine{% if machine.error %} problem{% endif %}">
+    <h2>{{ machine.name }}</h2>
+
+    {% if machine.error_kind == 'cannot_connect' %}
+    <p class="status"><strong>Cannot be reached.</strong> {{ machine.error }}</p>
+    <p class="muted">Check the address, that BOINC is running there, and that it is allowed to
+    accept connections from this app.</p>
+
+    {% elif machine.error_kind == 'auth_failed' %}
+    <p class="status"><strong>Rejected the password.</strong></p>
+    <p class="muted">It has to be exactly the GUI RPC password set on that machine.</p>
+
+    {% elif machine.error_kind == 'not_configured' %}
+    <p class="status"><strong>Not fully configured.</strong> {{ machine.error }}</p>
+
+    {% elif machine.error %}
+    <p class="status"><strong>Something went wrong.</strong> {{ machine.error }}</p>
+
+    {% else %}
+    <p class="status">{{ machine.state.activity }}</p>
+    <p class="counts">
+      {{ machine.state.running | length }} running ·
+      {{ machine.state.queued }} waiting ·
+      {{ machine.state.ready_to_report }} finished
+    </p>
+
+    {% if machine.state.running %}
+    <table>
+      <thead>
+        <tr><th>Project</th><th>Progress</th><th class="due">Due</th></tr>
+      </thead>
+      <tbody>
+        {% for task in machine.state.running %}
+        <tr title="{{ task.name }}">
+          <td>{{ task.project }}</td>
+          <td>
+            {% if task.fraction_done is not none %}
+            <progress value="{{ task.fraction_done }}" max="1"></progress>
+            <span class="pct">{{ '%.0f' | format(task.fraction_done * 100) }}%</span>
+            {% else %}—{% endif %}
+          </td>
+          <td class="due">{{ task.deadline | due }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% elif machine.state.queued or machine.state.ready_to_report %}
+    <p class="muted">Nothing is running right now.</p>
+    {% else %}
+    <p class="muted">This machine has no tasks.</p>
+    {% endif %}
+
+    {% if machine.state.projects %}
+    <p class="counts">Projects:
+      {% for project in machine.state.projects %}{{ project.name }}{% if not loop.last %}, {% endif %}{% endfor %}
+    </p>
+    {% else %}
+    <p class="counts">Not attached to any project.</p>
+    {% endif %}
+    {% endif %}
+  </div>
+  {% endfor %}
 {% endif %}
 
 <form method="post" action="refresh">

--- a/boincui/server/test/test_app.py
+++ b/boincui/server/test/test_app.py
@@ -1,29 +1,51 @@
 import sys
 import threading
 import unittest
+from datetime import datetime, timedelta
 from html.parser import HTMLParser
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import app as app_module  # noqa: E402
-from app import Refresher, Snapshot, create_app  # noqa: E402
-from boinc import AuthenticationFailed, BoincError, CannotConnect, NotConfigured  # noqa: E402
+from app import Refresher, Snapshot, clients_from, create_app, format_due  # noqa: E402
 
 # An URL that is fine to emit absolutely: it leaves the panel on purpose, or does not navigate.
 EXTERNAL_PREFIXES = ('http://', 'https://', 'mailto:', '#')
 
 URL_ATTRIBUTES = ('href', 'src', 'action', 'formaction')
 
-CONNECTED_STATE = {
-    'cc_status': {'task_mode': 2},
-    'projects': [{'master_url': 'https://example.org/', 'project_name': 'Example'}],
-    'results': [{
-        'name': 'task_one',
-        'project_url': 'https://example.org/',
-        'active_task': {'active_task_state': 1, 'fraction_done': 0.25},
-    }],
-}
+
+def machine(name='pc', error=None, error_kind=None, running=(), queued=0, ready=0,
+            projects=(('Example Project', 'https://example.org/'),), activity='Computing — always computing'):
+    return {
+        'name': name,
+        'host': 'pc.local',
+        'error': error,
+        'error_kind': error_kind,
+        'state': None if error else {
+            'activity': activity,
+            'running': list(running),
+            'queued': queued,
+            'ready_to_report': ready,
+            'projects': [{'name': n, 'url': u} for n, u in projects],
+        },
+    }
+
+
+def task(name='task_one', project='Example Project', fraction_done=0.25, deadline=None):
+    return {
+        'name': name,
+        'project': project,
+        'fraction_done': fraction_done,
+        'deadline': deadline if deadline is not None else datetime.now() + timedelta(days=2),
+    }
+
+
+def snapshot_of(*machines):
+    snapshot = Snapshot()
+    snapshot.store(list(machines))
+    return snapshot
 
 
 class UrlCollector(HTMLParser):
@@ -45,18 +67,6 @@ def client_for(snapshot):
     return app.test_client()
 
 
-def snapshot_failing_with(error):
-    snapshot = Snapshot()
-    snapshot.fail(error)
-    return snapshot
-
-
-def snapshot_connected():
-    snapshot = Snapshot()
-    snapshot.store(CONNECTED_STATE)
-    return snapshot
-
-
 class TestStates(unittest.TestCase):
     """Every state the page can be in, rendered without touching the network."""
 
@@ -66,56 +76,126 @@ class TestStates(unittest.TestCase):
         return response.get_data(as_text=True)
 
     def test_should_say_it_is_still_checking_before_the_first_refresh(self):
-        self.assertIn('Checking the BOINC client', self.page_for(Snapshot()))
+        self.assertIn('Checking your BOINC clients', self.page_for(Snapshot()))
 
-    def test_should_explain_what_to_fill_in_when_not_configured(self):
-        page = self.page_for(snapshot_failing_with(NotConfigured('nothing set')))
+    def test_should_explain_what_to_fill_in_when_nothing_is_configured(self):
+        page = self.page_for(snapshot_of())
 
         self.assertIn('No BOINC client is configured', page)
         self.assertIn('Configuration tab', page)
 
-    def test_should_show_the_address_it_tried_when_it_cannot_connect(self):
-        page = self.page_for(snapshot_failing_with(CannotConnect('Could not reach a BOINC client at boinc-host:31416')))
+    def test_should_show_running_tasks_with_progress_and_deadline(self):
+        page = self.page_for(snapshot_of(machine(running=[task()], queued=12, ready=2)))
 
-        self.assertIn('Cannot reach the BOINC client', page)
-        self.assertIn('boinc-host:31416', page)
-
-    def test_should_point_at_the_password_when_it_is_rejected(self):
-        page = self.page_for(snapshot_failing_with(AuthenticationFailed('rejected')))
-
-        self.assertIn('rejected the password', page)
-
-    def test_should_still_render_on_an_unexpected_failure(self):
-        page = self.page_for(snapshot_failing_with(BoincError('Unexpected reply')))
-
-        self.assertIn('Something went wrong', page)
-        self.assertIn('Unexpected reply', page)
-
-    def test_should_list_tasks_and_projects_when_connected(self):
-        page = self.page_for(snapshot_connected())
-
-        self.assertIn('task_one', page)
+        self.assertIn('Example Project', page)
         self.assertIn('25%', page)
-        self.assertIn('Example', page)
+        self.assertIn('in 1 day', page)
+        self.assertIn('12 waiting', page)
+        self.assertIn('2 finished', page)
 
-    def test_should_keep_the_last_state_visible_when_a_refresh_fails(self):
-        # A single failed poll should not blank a page that was working a minute ago.
-        snapshot = snapshot_connected()
-        snapshot.fail(CannotConnect('Could not reach a BOINC client at boinc-host:31416'))
+    def test_should_keep_the_task_identifier_out_of_the_way_but_reachable(self):
+        # BOINC's names say nothing to a reader, but they are what you would search for in boinctui.
+        page = self.page_for(snapshot_of(machine(running=[task(name='LATeah4013L03_925.0_0')])))
 
-        page = self.page_for(snapshot)
+        self.assertIn('title="LATeah4013L03_925.0_0"', page)
+        self.assertNotIn('>LATeah4013L03_925.0_0<', page)
 
-        self.assertIn('Cannot reach the BOINC client', page)
-        self.assertIn('task_one', page)
+    def test_should_say_when_a_connected_machine_is_running_nothing(self):
+        page = self.page_for(snapshot_of(machine(running=[], queued=5)))
 
-    def test_should_say_there_are_no_tasks_rather_than_showing_nothing(self):
-        snapshot = Snapshot()
-        snapshot.store({'cc_status': {}, 'projects': [], 'results': []})
+        self.assertIn('Nothing is running right now', page)
 
-        page = self.page_for(snapshot)
+    def test_should_show_why_a_machine_is_paused(self):
+        page = self.page_for(snapshot_of(machine(activity='Paused — the processor is busy with something else')))
 
-        self.assertIn('No tasks', page)
-        self.assertIn('not attached to any project', page)
+        self.assertIn('the processor is busy', page)
+
+    def test_should_report_each_failure_kind_against_its_own_machine(self):
+        for kind, expected in (
+            ('cannot_connect', 'Cannot be reached'),
+            ('auth_failed', 'Rejected the password'),
+            ('not_configured', 'Not fully configured'),
+            ('error', 'Something went wrong'),
+        ):
+            with self.subTest(kind=kind):
+                page = self.page_for(snapshot_of(machine(error='boom', error_kind=kind)))
+                self.assertIn(expected, page)
+
+    def test_should_still_show_the_machines_that_work_when_one_is_broken(self):
+        page = self.page_for(snapshot_of(
+            machine(name='broken', error='boom', error_kind='cannot_connect'),
+            machine(name='working', running=[task(project='Rosetta@home')]),
+        ))
+
+        self.assertIn('Cannot be reached', page)
+        self.assertIn('working', page)
+        self.assertIn('Rosetta@home', page)
+
+    def test_should_render_a_section_per_machine_in_configured_order(self):
+        page = self.page_for(snapshot_of(machine(name='first'), machine(name='second')))
+
+        self.assertLess(page.index('first'), page.index('second'))
+
+
+class TestFormatDue(unittest.TestCase):
+
+    def test_should_describe_a_deadline_in_readable_units(self):
+        # Each delta carries a small margin because format_due reads the clock itself: the unit is
+        # truncated, never rounded up, so a deadline is never described as further away than it is.
+        now = datetime.now()
+        for delta, expected in (
+            (timedelta(days=3, minutes=1), 'in 3 days'),
+            (timedelta(days=1, hours=2), 'in 1 day'),
+            (timedelta(hours=5, minutes=1), 'in 5 hours'),
+            (timedelta(minutes=90), 'in 1 hour'),
+            (timedelta(seconds=30), 'in under a minute'),
+            (timedelta(days=-1), 'overdue'),
+        ):
+            with self.subTest(delta=delta):
+                self.assertEqual(expected, format_due(now + delta))
+
+    def test_should_never_overstate_the_time_left(self):
+        # Truncating up would tell someone they have three days when they have two and a bit.
+        self.assertEqual('in 2 days', format_due(datetime.now() + timedelta(days=2, hours=23)))
+
+    def test_should_cope_with_a_task_that_has_no_deadline(self):
+        self.assertEqual('—', format_due(None))
+
+    def test_should_not_mix_naive_and_aware_datetimes(self):
+        # Deadlines arrive naive; comparing them against an aware "now" raises TypeError, which
+        # would take the whole page down rather than one cell.
+        try:
+            format_due(datetime.now() + timedelta(days=1))
+        except TypeError as error:
+            self.fail(f'format_due compared incompatible datetimes: {error}')
+
+
+class TestClientsFrom(unittest.TestCase):
+
+    def test_should_use_the_client_list_when_present(self):
+        clients = clients_from({'clients': [{'host': 'a', 'password': 'x'}]})
+
+        self.assertEqual([{'host': 'a', 'password': 'x'}], clients)
+
+    def test_should_accept_the_old_single_client_options(self):
+        # Supervisor silently drops options missing from the schema, so removing these outright
+        # would wipe an existing configuration. It still has to say so in the log.
+        with self.assertLogs(level='WARNING') as logged:
+            clients = clients_from({'boinc_host': 'pc', 'boinc_port': 31417, 'gui_rpc_password': 'x'})
+
+        self.assertEqual([{'name': 'pc', 'host': 'pc', 'port': 31417, 'password': 'x'}], clients)
+        self.assertIn('will stop working', ''.join(logged.output))
+
+    def test_should_prefer_the_list_over_the_old_options(self):
+        clients = clients_from({
+            'clients': [{'host': 'new', 'password': 'x'}],
+            'boinc_host': 'old', 'gui_rpc_password': 'y',
+        })
+
+        self.assertEqual('new', clients[0]['host'])
+
+    def test_should_return_nothing_when_unconfigured(self):
+        self.assertEqual([], clients_from({}))
 
 
 class TestIngressConstraint(unittest.TestCase):
@@ -141,8 +221,9 @@ class TestIngressConstraint(unittest.TestCase):
     def test_should_never_emit_a_root_relative_url_in_any_state(self):
         for name, snapshot in (
             ('checking', Snapshot()),
-            ('not configured', snapshot_failing_with(NotConfigured('nothing set'))),
-            ('connected', snapshot_connected()),
+            ('unconfigured', snapshot_of()),
+            ('connected', snapshot_of(machine(running=[task()]))),
+            ('broken', snapshot_of(machine(error='boom', error_kind='cannot_connect'))),
         ):
             with self.subTest(state=name):
                 self.assert_no_root_relative_urls(client_for(snapshot).get('/').get_data(as_text=True))
@@ -161,8 +242,8 @@ class TestIngressConstraint(unittest.TestCase):
 class TestRefreshButton(unittest.TestCase):
 
     def test_should_ask_for_a_poll_without_waiting_for_it(self):
-        # Polling inline would hold the request for as long as the BOINC host takes to answer, which
-        # is the very thing the background refresher exists to avoid.
+        # Polling inline would hold the request for as long as the slowest machine takes to answer,
+        # which is the very thing the background refresher exists to avoid.
         calls = []
         app = create_app(Snapshot())
         app.config['REFRESHER'] = type('FakeRefresher', (), {
@@ -185,8 +266,8 @@ class TestRefresher(unittest.TestCase):
         # Without this the button would do nothing visible until the next scheduled poll, which is a
         # minute away.
         polls = threading.Semaphore(0)
-        original = app_module.read_state
-        app_module.read_state = lambda *args: polls.release() or {'cc_status': {}, 'projects': [], 'results': []}
+        original = app_module.read_all
+        app_module.read_all = lambda clients: polls.release() or []
         stop = threading.Event()
         refresher = Refresher(Snapshot(), {}, stop)
         try:
@@ -200,7 +281,7 @@ class TestRefresher(unittest.TestCase):
             stop.set()
             refresher.request_refresh()
             refresher.join(timeout=10)
-            app_module.read_state = original
+            app_module.read_all = original
 
 
 if __name__ == '__main__':

--- a/boincui/server/test/test_boinc.py
+++ b/boincui/server/test/test_boinc.py
@@ -9,33 +9,56 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import boinc  # noqa: E402
-from boinc import AuthenticationFailed, CannotConnect, NotConfigured, read_state  # noqa: E402
+from boinc import read_all  # noqa: E402
 
 END = b'\x03'
 PASSWORD = 'correct horse'
 
-NO_TASKS = '<boinc_gui_rpc_reply>\n<results>\n</results>\n</boinc_gui_rpc_reply>'
-ONE_TASK = """<boinc_gui_rpc_reply>
-<results>
-<result>
-<name>task_one</name>
-<project_url>https://example.org/</project_url>
+
+def results_reply(*results: str) -> str:
+    return '<boinc_gui_rpc_reply>\n<results>\n' + '\n'.join(results) + '\n</results>\n</boinc_gui_rpc_reply>'
+
+
+def running_task(name='task_one', url='https://example.org/', done='0.25', deadline='4102444800'):
+    return f"""<result>
+<name>{name}</name>
+<project_url>{url}</project_url>
+<report_deadline>{deadline}</report_deadline>
 <active_task>
 <active_task_state>1</active_task_state>
-<fraction_done>0.25</fraction_done>
+<fraction_done>{done}</fraction_done>
 </active_task>
-</result>
-</results>
-</boinc_gui_rpc_reply>"""
+</result>"""
+
+
+QUEUED_TASK = """<result>
+<name>waiting_one</name>
+<project_url>https://example.org/</project_url>
+</result>"""
+
+FINISHED_TASK = """<result>
+<name>done_one</name>
+<project_url>https://example.org/</project_url>
+<ready_to_report>1</ready_to_report>
+</result>"""
+
 PROJECTS = """<boinc_gui_rpc_reply>
 <projects>
 <project>
 <master_url>https://example.org/</master_url>
-<project_name>Example</project_name>
+<project_name>Example Project</project_name>
 </project>
 </projects>
 </boinc_gui_rpc_reply>"""
-CC_STATUS = '<boinc_gui_rpc_reply>\n<cc_status>\n<task_mode>2</task_mode>\n</cc_status>\n</boinc_gui_rpc_reply>'
+
+NO_PROJECTS = '<boinc_gui_rpc_reply>\n<projects>\n</projects>\n</boinc_gui_rpc_reply>'
+NO_TASKS = results_reply()
+
+
+def cc_status(mode=2, suspend_reason=0):
+    return (f'<boinc_gui_rpc_reply>\n<cc_status>\n<task_mode>{mode}</task_mode>\n'
+            f'<task_suspend_reason>{suspend_reason}</task_suspend_reason>\n'
+            '</cc_status>\n</boinc_gui_rpc_reply>')
 
 
 class FakeBoincClient:
@@ -45,9 +68,11 @@ class FakeBoincClient:
     and <auth2> is accepted only when it carries md5(nonce + password).
     """
 
-    def __init__(self, password=PASSWORD, tasks=ONE_TASK):
+    def __init__(self, password=PASSWORD, tasks=None, projects=PROJECTS, status=None):
         self.password = password
-        self.tasks = tasks
+        self.tasks = tasks if tasks is not None else results_reply(running_task())
+        self.projects = projects
+        self.status = status if status is not None else cc_status()
         self.connections_seen = 0
         self.connections_closed = 0
         self._server = None
@@ -77,12 +102,13 @@ class FakeBoincClient:
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
 
+    def as_client(self, name):
+        return {'name': name, 'host': '127.0.0.1', 'port': self.port, 'password': PASSWORD}
+
     def _serve(self, ready):
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
-        self._server = self._loop.run_until_complete(
-            asyncio.start_server(self._handle, '127.0.0.1', 0)
-        )
+        self._server = self._loop.run_until_complete(asyncio.start_server(self._handle, '127.0.0.1', 0))
         self.port = self._server.sockets[0].getsockname()[1]
         ready.set()
         self._loop.run_forever()
@@ -90,7 +116,6 @@ class FakeBoincClient:
     async def _handle(self, reader, writer):
         self.connections_seen += 1
         nonce = '1234567890'
-        authorized = False
         try:
             while True:
                 request = (await reader.readuntil(END)).decode('ISO-8859-1')
@@ -98,13 +123,12 @@ class FakeBoincClient:
                     reply = f'<boinc_gui_rpc_reply>\n<nonce>{nonce}</nonce>\n</boinc_gui_rpc_reply>'
                 elif '<auth2' in request:
                     expected = md5((nonce + self.password).encode('UTF8')).hexdigest()
-                    authorized = expected in request
-                    tag = 'authorized' if authorized else 'unauthorized'
+                    tag = 'authorized' if expected in request else 'unauthorized'
                     reply = f'<boinc_gui_rpc_reply>\n<{tag}/>\n</boinc_gui_rpc_reply>'
                 elif '<get_cc_status' in request:
-                    reply = CC_STATUS
+                    reply = self.status
                 elif '<get_project_status' in request:
-                    reply = PROJECTS
+                    reply = self.projects
                 elif '<get_results' in request:
                     reply = self.tasks
                 else:
@@ -118,64 +142,160 @@ class FakeBoincClient:
             writer.close()
 
 
-class TestReadState(unittest.TestCase):
+def refused_port():
+    with socket.socket() as taken:
+        taken.bind(('127.0.0.1', 0))
+        return taken.getsockname()[1]
 
-    def test_should_read_tasks_and_projects(self):
+
+class TestSingleClient(unittest.TestCase):
+
+    def read_one(self, server, **overrides):
+        client = server.as_client('machine')
+        client.update(overrides)
+        return read_all([client])[0]
+
+    def test_should_read_running_tasks_with_their_project_name(self):
         with FakeBoincClient() as server:
-            state = read_state('127.0.0.1', server.port, PASSWORD)
+            machine = self.read_one(server)
 
-        self.assertEqual('task_one', state['results'][0]['name'])
-        self.assertEqual(0.25, state['results'][0]['active_task']['fraction_done'])
-        self.assertEqual('Example', state['projects'][0]['project_name'])
+        self.assertIsNone(machine['error'])
+        running = machine['state']['running']
+        self.assertEqual(1, len(running))
+        # Tasks only carry a URL; the readable name comes from joining against the project list.
+        self.assertEqual('Example Project', running[0]['project'])
+        self.assertEqual(0.25, running[0]['fraction_done'])
+        self.assertEqual('task_one', running[0]['name'])
+
+    def test_should_count_waiting_and_finished_tasks_without_listing_them(self):
+        # A machine with a work buffer has dozens queued; the page shows what is running and counts
+        # the rest.
+        tasks = results_reply(running_task(), QUEUED_TASK, QUEUED_TASK, FINISHED_TASK)
+        with FakeBoincClient(tasks=tasks) as server:
+            state = self.read_one(server)['state']
+
+        self.assertEqual(1, len(state['running']))
+        self.assertEqual(2, state['queued'])
+        self.assertEqual(1, state['ready_to_report'])
+
+    def test_should_sort_running_tasks_by_deadline_and_tolerate_a_missing_one(self):
+        no_deadline = running_task(name='undated').replace('<report_deadline>4102444800</report_deadline>\n', '')
+        tasks = results_reply(
+            running_task(name='later', deadline='4102531200'),
+            no_deadline,
+            running_task(name='sooner', deadline='4102444800'),
+        )
+        with FakeBoincClient(tasks=tasks) as server:
+            running = self.read_one(server)['state']['running']
+
+        self.assertEqual(['sooner', 'later', 'undated'], [task['name'] for task in running])
+
+    def test_should_fall_back_to_the_url_when_the_project_has_no_name(self):
+        with FakeBoincClient(projects=NO_PROJECTS) as server:
+            running = self.read_one(server)['state']['running']
+
+        self.assertEqual('https://example.org/', running[0]['project'])
+        self.assertIsInstance(running[0]['project'], str)
+
+    def test_should_describe_why_a_client_is_paused(self):
+        with FakeBoincClient(status=cc_status(suspend_reason=1024)) as server:
+            state = self.read_one(server)['state']
+
+        self.assertIn('Paused', state['activity'])
+        self.assertIn('processor is busy', state['activity'])
+
+    def test_should_not_break_on_a_suspend_reason_it_does_not_know(self):
+        with FakeBoincClient(status=cc_status(suspend_reason=99999)) as server:
+            state = self.read_one(server)['state']
+
+        self.assertIn('Paused', state['activity'])
+        self.assertIn('did not say why', state['activity'])
 
     def test_should_report_a_rejected_password_rather_than_empty_data(self):
         # The library does not check authorisation on its query methods, so without our explicit
         # check a wrong password would look like a client with nothing to do.
         with FakeBoincClient() as server:
-            with self.assertRaises(AuthenticationFailed):
-                read_state('127.0.0.1', server.port, 'wrong password')
+            machine = self.read_one(server, password='wrong password')
+
+        self.assertEqual('auth_failed', machine['error_kind'])
 
     def test_should_treat_the_no_tasks_sentinel_as_an_empty_list(self):
         # With no results the library returns the string "\n" instead of a list.
-        with FakeBoincClient(tasks=NO_TASKS) as server:
-            state = read_state('127.0.0.1', server.port, PASSWORD)
+        with FakeBoincClient(tasks=NO_TASKS, projects=NO_PROJECTS) as server:
+            state = self.read_one(server)['state']
 
-        self.assertEqual([], state['results'])
+        self.assertEqual([], state['running'])
+        self.assertEqual([], state['projects'])
 
     def test_should_close_the_connection_it_opened(self):
         # Upstream never closes the socket; this is what the vendored close() patch is for.
         with FakeBoincClient() as server:
-            read_state('127.0.0.1', server.port, PASSWORD)
-            deadline = threading.Event()
-            deadline.wait(0.5)
+            self.read_one(server)
+            threading.Event().wait(0.5)
 
             self.assertEqual(1, server.connections_seen)
             self.assertEqual(1, server.connections_closed)
 
     def test_should_report_a_host_that_refuses_the_connection(self):
-        with socket.socket() as taken:
-            taken.bind(('127.0.0.1', 0))
-            unused_port = taken.getsockname()[1]
+        machine = read_all([{'name': 'off', 'host': '127.0.0.1', 'port': refused_port(), 'password': PASSWORD}])[0]
 
-        with self.assertRaises(CannotConnect):
-            read_state('127.0.0.1', unused_port, PASSWORD)
+        self.assertEqual('cannot_connect', machine['error_kind'])
 
-    def test_should_report_missing_configuration_without_touching_the_network(self):
-        for host, password in ((None, PASSWORD), ('127.0.0.1', None), (None, None)):
-            with self.subTest(host=host, password=password):
-                with self.assertRaises(NotConfigured):
-                    read_state(host, 31416, password)
+    def test_should_report_a_client_missing_its_address_or_password(self):
+        for client in ({'host': None, 'password': PASSWORD}, {'host': '127.0.0.1', 'password': None}):
+            with self.subTest(client=client):
+                self.assertEqual('not_configured', read_all([client])[0]['error_kind'])
 
     def test_should_default_the_port_when_none_is_configured(self):
         with FakeBoincClient() as server:
-            original = boinc.DEFAULT_PORT
-            boinc.DEFAULT_PORT = server.port
+            original, boinc.DEFAULT_PORT = boinc.DEFAULT_PORT, server.port
             try:
-                state = read_state('127.0.0.1', None, PASSWORD)
+                machine = read_all([{'host': '127.0.0.1', 'password': PASSWORD}])[0]
             finally:
                 boinc.DEFAULT_PORT = original
 
-        self.assertEqual('task_one', state['results'][0]['name'])
+        self.assertIsNone(machine['error'])
+
+    def test_should_name_a_client_after_its_address_when_unnamed(self):
+        with FakeBoincClient() as server:
+            machine = read_all([{'host': '127.0.0.1', 'port': server.port, 'password': PASSWORD}])[0]
+
+        self.assertEqual('127.0.0.1', machine['name'])
+
+
+class TestSeveralClients(unittest.TestCase):
+
+    def test_should_read_every_machine(self):
+        with FakeBoincClient(tasks=results_reply(running_task(name='on_first'))) as first, \
+                FakeBoincClient(tasks=results_reply(running_task(name='on_second'))) as second:
+            machines = read_all([first.as_client('first'), second.as_client('second')])
+
+        self.assertEqual(['first', 'second'], [machine['name'] for machine in machines])
+        self.assertEqual('on_first', machines[0]['state']['running'][0]['name'])
+        self.assertEqual('on_second', machines[1]['state']['running'][0]['name'])
+
+    def test_should_keep_showing_the_machines_that_answer_when_one_does_not(self):
+        # The reason every machine is polled concurrently with errors collected rather than raised:
+        # one that is switched off must not cost you the others.
+        unreachable = {'name': 'off', 'host': '127.0.0.1', 'port': refused_port(), 'password': PASSWORD}
+        with FakeBoincClient() as server:
+            machines = read_all([unreachable, server.as_client('on')])
+
+        self.assertEqual('cannot_connect', machines[0]['error_kind'])
+        self.assertIsNone(machines[1]['error'])
+        self.assertEqual(1, len(machines[1]['state']['running']))
+
+    def test_should_isolate_a_wrong_password_to_its_own_machine(self):
+        with FakeBoincClient() as first, FakeBoincClient() as second:
+            bad = first.as_client('bad')
+            bad['password'] = 'wrong password'
+            machines = read_all([bad, second.as_client('good')])
+
+        self.assertEqual('auth_failed', machines[0]['error_kind'])
+        self.assertIsNone(machines[1]['error'])
+
+    def test_should_return_nothing_when_no_client_is_configured(self):
+        self.assertEqual([], read_all([]))
 
 
 if __name__ == '__main__':

--- a/boincui/translations/en.yaml
+++ b/boincui/translations/en.yaml
@@ -1,10 +1,25 @@
 configuration:
-  boinc_host:
-    name: BOINC client address
+  clients:
+    name: BOINC clients
+    description: "The machines running BOINC that you want to watch. Add one entry per machine; each of them also has to be set up to accept the connection"
+  name:
+    name: Name
+    description: "What to call this machine on the page. Optional — its address is used if you leave it empty"
+  host:
+    name: Address
     description: "Hostname or IP address of the machine running BOINC. For the BOINC app on this same Home Assistant, use the hostname shown on its Info page"
+  port:
+    name: Port
+    description: "Port this client listens on for remote control. Leave empty unless you changed it; BOINC uses 31416"
+  password:
+    name: Password
+    description: "Must match the GUI RPC password set on that machine. Without it the client refuses the connection"
+  boinc_host:
+    name: BOINC client address (old setting)
+    description: "Replaced by the client list above. Move your settings there; this will stop working in a future version"
   boinc_port:
-    name: BOINC client port
-    description: "Port the BOINC client listens on for remote control. Leave empty unless you changed it; BOINC uses 31416"
+    name: BOINC client port (old setting)
+    description: "Replaced by the client list above. Move your settings there; this will stop working in a future version"
   gui_rpc_password:
-    name: BOINC client password
-    description: "Must match the GUI RPC password set in the BOINC app's configuration. Without it the client refuses the connection"
+    name: BOINC client password (old setting)
+    description: "Replaced by the client list above. Move your settings there; this will stop working in a future version"

--- a/boincui/translations/es.yaml
+++ b/boincui/translations/es.yaml
@@ -1,10 +1,25 @@
 configuration:
+  clients:
+    name: Clientes BOINC
+    description: "Las máquinas que ejecutan BOINC y quieres vigilar. Añade una entrada por máquina; cada una tiene que estar configurada además para aceptar la conexión"
+  name:
+    name: Nombre
+    description: "Cómo se llama esta máquina en la página. Opcional: si lo dejas vacío se usa su dirección"
+  host:
+    name: Dirección
+    description: "Nombre de host o dirección IP de la máquina que ejecuta BOINC. Si es la aplicación BOINC de este mismo Home Assistant, usa el nombre de host de su página de información"
+  port:
+    name: Puerto
+    description: "Puerto en el que este cliente escucha las conexiones de control remoto. Déjalo vacío salvo que lo hayas cambiado; BOINC usa el 31416"
+  password:
+    name: Contraseña
+    description: "Tiene que coincidir con la contraseña de GUI RPC de esa máquina. Sin ella el cliente rechaza la conexión"
   boinc_host:
-    name: Dirección del cliente BOINC
-    description: "Nombre de host o dirección IP de la máquina que ejecuta BOINC. Si es la aplicación BOINC de este mismo Home Assistant, usa el nombre de host que aparece en su página de información"
+    name: Dirección del cliente BOINC (ajuste antiguo)
+    description: "Sustituido por la lista de clientes de arriba. Mueve ahí tus ajustes; esto dejará de funcionar en una versión futura"
   boinc_port:
-    name: Puerto del cliente BOINC
-    description: "Puerto en el que el cliente BOINC escucha las conexiones de control remoto. Déjalo vacío salvo que lo hayas cambiado; BOINC usa el 31416"
+    name: Puerto del cliente BOINC (ajuste antiguo)
+    description: "Sustituido por la lista de clientes de arriba. Mueve ahí tus ajustes; esto dejará de funcionar en una versión futura"
   gui_rpc_password:
-    name: Contraseña del cliente BOINC
-    description: "Tiene que coincidir con la contraseña de GUI RPC configurada en la aplicación BOINC. Sin ella el cliente rechaza la conexión"
+    name: Contraseña del cliente BOINC (ajuste antiguo)
+    description: "Sustituido por la lista de clientes de arriba. Mueve ahí tus ajustes; esto dejará de funcionar en una versión futura"


### PR DESCRIPTION
## Why

The single client this add-on could reach has no tasks, so the part of the page that matters most could not be looked at. Machines are now a list, each with its own section.

## The UX, decided before writing code

**Per-machine sections, not one aggregated table.** `TODO.md` had cross-machine aggregation recorded as the thing that would set this apart from `boinctui` and the HACS integration — both talk to several machines, neither joins them. Per-machine was chosen instead: it is how people think about their computers. Worth stating plainly, because it means what distinguishes this UI is now being graphical and usable on a phone, not aggregation.

**Only running tasks are listed.** `get_results()` returns *every* task, and a machine with a normal work buffer has dozens queued — unreadable on a phone. A line counts the rest (waiting / finished); the full queue is what `boinctui` is for.

**No task identifiers in the table.** `LATeah4013L03_925.0_0_0.0_12345_1` says nothing to a reader. It lives in the row's `title`, and the row shows the project name — which requires joining tasks to projects, since a task only carries a URL.

**Each machine says why it is not computing.** The most confusing situation is "it connects fine and nothing is running". Usually the time of day or a busy processor.

## Implementation notes

**Concurrent polling, errors collected not raised.** A switched-off machine costs only itself: a cycle takes as long as the slowest machine rather than the sum, and its section shows the error while the others render. This is the first change where the library being asyncio pays for itself instead of being ceremony.

**Suspend reasons copied from BOINC, not invented.** They look like a bitmask up to 4096, but 4097–4103 are sequential and would collide with combinations (4097 == 4096|1). BOINC matches the exact value with a fallback (`lib/str_util.cpp`), so we do too — with a test for an unknown code.

**Two parser traps fixed** while the code was being touched: `project_url` is a library object, not a string (it rendered correctly by accident of `__str__`, which stops working once you join on it), and `report_deadline` is a *naive* datetime while `Snapshot.updated` is aware — mixing them in a comparison raises `TypeError`, so the "due in" filter keeps both naive.

## Migration, and what the real Supervisor caught

The old single-client options are kept for one version, since Supervisor drops options missing from the schema without telling anyone.

That turned out not to be enough, and only a real Supervisor showed it: **a list-of-dict option cannot be marked optional.** The missing-option check honours a trailing `?` only on a string, and for a list it inspects the first element — a dict here (`apps/options.py`, `_check_missing_options`). Without a default, an empty configuration fails validation, so neither a fresh install nor an upgrade would start. Fixed with an `options:` block defaulting `clients` to `[]`, which Supervisor merges under the user's own options at start.

Verified by actually doing the upgrade: install 0.3.0, configure it, upgrade in place.

```
version: 0.4.0 | state: started
options: {'clients': [], 'boinc_host': 'local-boinc', 'gui_rpc_password': 'testpass123'}
WARNING Using the old single-client options. Move them to the "clients" list...
```

## Verification

43 unit tests (up from 24), green on the local Python and on the image's 3.13. Against the devcontainer's Supervisor:

- **After migration**, the page renders one section named `local-boinc`, computing, with counts.
- **Two machines — the BOINC add-on and an unreachable address** — render together: `['BOINC add-on', 'portatil apagado']`, one *Computing*, the other *Cannot be reached*. That is the partial-failure case working.
- No root-relative URLs in any state, still.

`yamllint`, `hadolint`, `mkdocs build --strict` and `smoke.sh boincui` all pass.

Still `stage: experimental`, so this is built and published but not announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP