### PR TITLE
feat(boincui): start and stop computing from the page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 For what this repo is, how to install it, and per-app end-user docs, see:
 [README.md](README.md), [boinc/README.md](boinc/README.md) + [boinc/DOCS.md](boinc/DOCS.md) +
 [boinc/DEVELOPMENT.md](boinc/DEVELOPMENT.md), [boinctui/README.md](boinctui/README.md) +
-[boinctui/DOCS.md](boinctui/DOCS.md), and [boinc/operator/README.md](boinc/operator/README.md).
+[boinctui/DOCS.md](boinctui/DOCS.md), [boincui/README.md](boincui/README.md) +
+[boincui/DOCS.md](boincui/DOCS.md) + [boincui/DEVELOPMENT.md](boincui/DEVELOPMENT.md), and
+[boinc/operator/README.md](boinc/operator/README.md).
 This file only covers what those don't: internal architecture and contributor workflow.
+
+[boincui/DEVELOPMENT.md](boincui/DEVELOPMENT.md) additionally carries **the UI and UX decisions for
+`boincui`, with the reasoning and the evidence behind each one**. Read it before changing how that
+page looks or behaves, and add to it when a new decision is made — otherwise the argument gets had
+again from scratch, which has already happened more than once.
 
 [TODO.md](TODO.md) is the standing backlog of known bugs, HA-platform conformance gaps, and
 feature ideas found by review but not yet acted on. Consult it before starting work in this repo —
@@ -23,8 +30,9 @@ Three independent Home Assistant add-ons, each self-contained with its own `conf
   process.
 - **`boinctui/`** — a terminal UI (via `ttyd` + `boinctui`) for monitoring/controlling the BOINC
   client, exposed through Home Assistant ingress.
-- **`boincui/`** — a read-only graphical web interface served through ingress, intended to grow into
-  a BOINC Manager equivalent. `boincui/server/` is a Flask app rendered entirely on the server:
+- **`boincui/`** — a graphical web interface served through ingress, intended to grow into a BOINC
+  Manager equivalent. It reads every configured machine and can set each one's activity mode; it
+  cannot yet act on individual tasks. `boincui/server/` is a Flask app rendered entirely on the server:
   `app.py` holds the routes plus `Snapshot`/`Refresher`, `boinc.py` is the only module that talks to
   a BOINC client, and `main.py` runs it under waitress and owns the process lifecycle.
   `--exit-immediately` is the one-shot path used by CI; otherwise it blocks until signalled, because
@@ -36,18 +44,21 @@ Three independent Home Assistant add-ons, each self-contained with its own `conf
   1. **Every emitted URL must be relative** — ingress strips its prefix and does not pass it on (see
      the Gotchas in `.claude/skills/run-boinc-addons/SKILL.md`). `test_app.py` parses the rendered
      HTML and fails on any root-relative `href`/`src`/`action`, and on a root-relative `Location`.
-  2. **Views must never contact a BOINC host during a request.** `Refresher` polls on its own thread
-     and writes `Snapshot`; views only read it. A host that is switched off cannot stall the page,
-     and render time does not depend on how many hosts are configured.
+  2. **Rendering must never contact a BOINC host.** `Refresher` polls on its own thread and writes
+     `Snapshot`; views only read it. A host that is switched off cannot stall the page, and render
+     time does not depend on how many hosts are configured. An *action* is the one exception — it
+     runs its exchange inside the request, with a shorter deadline than the poll gets, because a
+     button press with no confirmation is worse than a slow one.
   3. **`boinc.py` is the only place that may import `pyboinc`.** It converts the library's asyncio
      API and its quirks into plain dicts and `BoincError` subclasses, so nothing above it knows the
      library exists.
 
 - **`boincui/server/pyboinc/`** is vendored third-party code (MIT), not ours — it has never been
   published to PyPI, so there is no version to depend on. `VENDOR.md` in that directory records the
-  upstream commit, the local patches (currently just an added `close()`, since upstream never closes
-  its socket) and the upstream quirks that `boinc.py` works around. Keep local changes minimal and
-  listed there; do not restyle it.
+  upstream commit, the local patches (an added `close()`, since upstream never closes its socket, and
+  a fix to the three `set_*_mode()` methods, whose entire write path raised `TypeError` before
+  reaching the socket) and the upstream quirks that `boinc.py` works around. Keep local changes
+  minimal and listed there; do not restyle it.
 
 Add-ons are versioned and released independently: each has its own semver in `config.yaml`, and CI
 only builds/releases an add-on when files inside its directory change (see CI section below).
@@ -146,8 +157,11 @@ pip install -r requirements.txt
 mkdocs build --strict   # or: mkdocs serve
 ```
 
-`mkdocs.yml` nav pulls each add-on's `README.md`, `DOCS.md`, and `CHANGELOG.md` directly, plus
-`boinc/DEVELOPMENT.md`.
+The nav in `mkdocs.yml` does **not** reach into the add-on directories. `docs/` is the docs dir and
+every page in it is a **symlink** to the real file (`docs/boincui/DOCS.md -> ../../boincui/DOCS.md`,
+`docs/index.md -> ../README.md`). Adding a page to the nav therefore means creating the symlink too,
+or `--strict` fails with "included in the 'nav' configuration, which is not found in the
+documentation files".
 
 ### Linting (mirrors CI, see `.github/workflows/lint.yaml`)
 

--- a/TODO.md
+++ b/TODO.md
@@ -215,6 +215,24 @@ Common BOINC global preferences not exposed, each roughly one key away in
 
 - [ ] **Prometheus metrics endpoint** — same data source, different consumer.
 
+- [ ] **Remove `boincui`'s deprecated single-client options in 0.6.0** — `boinc_host`, `boinc_port`
+  and `gui_rpc_password`, replaced by the `clients` list in 0.4.0. Held back from 0.5.0 on purpose:
+  they had been deprecated for a single released version, and Supervisor **silently discards options
+  that disappear from the schema**, so anyone who had not migrated would lose their configuration
+  with no warning. `clients_from` in `app.py` is the whole migration; deleting it also means dropping
+  the three entries from `translations/*.yaml` and the *Upgrading* section of `DOCS.md`.
+
+- [ ] **Localise `boincui`'s page.** Only `translations/*.yaml` is translated today, and that covers
+  configuration fields, not the page itself. If it is ever done, the activity control's wording
+  should come from BOINC's own catalogue rather than a third phrasing — `locale/es/BOINC-Manager.po`
+  has *Ejecutar siempre* / *Ejecutar según preferencias* / *Suspender* with their descriptions. See
+  the UI/UX section of `boincui/DEVELOPMENT.md`.
+
+- [ ] **Show how long a temporary activity mode has left.** `cc_status` already returns
+  `task_mode_delay` alongside `task_mode_perm`, in the reply `boincui` fetches anyway, so a machine
+  suspended for an hour from BOINC Manager could say so instead of just "paused". Needs a duration
+  formatter; `format_due` only handles deadlines.
+
 - [ ] **Publish a maintained fork of `pyboinc` to PyPI.** Deferred deliberately; `boincui` vendors it
   instead (see `boincui/server/pyboinc/VENDOR.md`). What is already established, so it is not
   re-derived:
@@ -230,6 +248,12 @@ Common BOINC global preferences not exposed, each roughly one key away in
     (OIDC) so there is no long-lived token. Plus folding in the fixes that already exist but are
     stranded upstream: SpuelMett's `str(duration)`, PR #1's Windows buffer fix, PR #2's typo, our
     `close()` and the `"\n"` normalisation.
+  - **The write path is broken upstream and in both forks**, which is the strongest reason yet to
+    publish a fixed one. All three `set_*_mode()` methods pass the duration where a tag name belongs,
+    so they raise `TypeError` before sending anything; `Igor-Misic` left it, and SpuelMett's
+    `str(duration)` stops the crash while silently dropping the duration, turning a timed change into
+    a permanent one. `boincui` carries the real fix (`ET.SubElement(req, Tag.DURATION)`), verified
+    against a running client — it is a three-line PR to upstream whenever the fork happens.
   - **This is what a Home Assistant core integration would require**, since core only accepts
     dependencies pinned as `<package>==<version>` from PyPI (`script/hassfest/requirements.py`).
   - Cost: a public package to maintain. Courtesy first: offer upstream to take over maintenance.
@@ -288,9 +312,12 @@ Common BOINC global preferences not exposed, each roughly one key away in
     - **Likely network gotcha — verify empirically.** Add-on ↔ add-on traffic stays on HA's Docker
       network and the target sees the container hostname. Traffic to a LAN machine is masqueraded,
       so the remote host most likely sees **the Home Assistant host's IP** — i.e. a remote PC's
-      `remote_hosts.cfg` needs a *different* entry than a sibling add-on does. This is inference
-      about Docker NAT, **not verified**; confirm with `tcpdump` or a remote BOINC's rejection log.
-      If true it is the first support question this will get, and both recipes belong in the docs.
+      `remote_hosts.cfg` needs a *different* entry than a sibling add-on does. **Strongly supported,
+      not yet confirmed on Home Assistant itself**: 2026-08-11, a BOINC client in a container reached
+      through a published port logged `GUI RPC request from non-allowed address 192.168.65.1`, the
+      Docker gateway rather than the caller. That is Docker Desktop's NAT, so the address a real HA
+      host presents still has to be checked there. Documented in `boincui/DOCS.md` as the likely
+      cause when a LAN machine refuses the connection.
     - **Security blast radius multiplies.** BOINC's GUI RPC has one password per client and no users
       or roles. A multi-host UI concentrates total control of every BOINC machine behind one ingress
       panel. **Verify whether HA can restrict an ingress panel to admin users**; if it cannot, any HA

--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.0
+
+You can now start and stop computing on each machine, under Activity: Run always, Run based on preferences, or Suspend. They are the same three choices, with the same names, that BOINC Manager offers
+
+The choice takes effect immediately and sticks, surviving a restart of BOINC and of the machine
+
+Careful with Run always: it makes that machine compute on battery, while you are using it, and outside the hours you set for it
+
+A machine that is running BOINC but refuses to let this app in now says so, instead of being reported as unreachable — they need different fixes
+
 ## 0.4.0
 
 You can now watch several BOINC machines at once, each with its own section on the page. Add them under BOINC clients in the Configuration tab

--- a/boincui/DEVELOPMENT.md
+++ b/boincui/DEVELOPMENT.md
@@ -1,0 +1,201 @@
+# Development
+
+## Build locally
+
+```bash
+docker build --progress=plain -t hectorespert/amd64-addon-boincui .
+```
+
+## Run locally
+
+The container blocks until it is signalled, so a foreground run looks like it has hung — that is
+deliberate: an entrypoint that returns leaves Supervisor reporting the app as stopped seconds after
+the user started it. Pass `--exit-immediately` for the one-shot path CI uses.
+
+```bash
+docker run --rm -p 8099:8099 -v $(pwd)/server/options.json:/data/options.json:ro \
+  hectorespert/amd64-addon-boincui
+```
+
+Running the server straight from a checkout is usually quicker. It needs `flask` and `waitress`, in
+a virtualenv rather than system-wide:
+
+```bash
+cd server
+python3 -m venv .venv && .venv/bin/pip install --quiet flask waitress
+.venv/bin/python main.py --options /path/to/options.json --log-level DEBUG
+```
+
+## Tests
+
+```bash
+cd server && .venv/bin/python -m unittest discover -s test -t test
+```
+
+The images run whatever `python3` Debian ships, which is not what a checkout runs. To exercise the
+suite on the version that actually gets published, mount it into the built image:
+
+```bash
+docker run --rm -v "$PWD/server:/src" -w /src \
+  --entrypoint python3 boincui-addon-test:local -m unittest discover -s test -t test
+```
+
+## Talking to a real BOINC client
+
+Unit tests run against a fake GUI RPC server, which cannot tell you whether a request BOINC has
+never seen is one it accepts. For anything that writes, drive a real client:
+
+```bash
+docker build -t boinc-addon-test:local ../boinc
+docker run -d --name boinc-probe -p 31416:31416 \
+  -v "$PWD/../boinc/operator/options.json:/data/options.json:ro" boinc-addon-test:local
+
+# Its own view, from a second tool, as a cross-check
+docker exec --workdir /data/boinc boinc-probe boinccmd --get_cc_status
+```
+
+Two things will bite you:
+
+- **`boinccmd` needs `--workdir /data/boinc`**, because it looks for `gui_rpc_auth.cfg` in the
+  working directory rather than taking a path.
+- **The client only listens beyond loopback when it has an allowed-hosts list or
+  `allow_remote_gui_rpc`** (`client/gui_rpc_server.cpp:326`), and it then checks the caller's address
+  *after* accepting the connection. Requests from the host arrive with the Docker gateway's address,
+  which the client logs as `GUI RPC request from non-allowed address 192.168.65.1`; put that address
+  in the `remote_hosts` option to get in.
+
+---
+
+# UI and UX decisions
+
+Why the page looks and behaves the way it does. These have all been argued once already — if you
+are about to change one, the reason it is here is so that you argue with the reason rather than
+rediscover it.
+
+## Everything is rendered on the server, and every URL is relative
+
+Home Assistant serves this app under `/api/hassio_ingress/<token>/` and **strips that prefix before
+forwarding, without telling the app what it was**: the only headers ingress adds are
+`X-Remote-User-*` and `X-Forwarded-For` (`supervisor/api/ingress.py`, `_create_url`). The token is
+generated at install time, so it is unknown when the image is built and when the container starts.
+
+An app that cannot know its own base URL cannot emit an absolute one. A root-relative `href`,
+`action` or `Location: /` sends the browser to the Home Assistant root and out of the panel. In
+Flask that also rules out `url_for` for links and redirects, since `redirect(url_for('index'))`
+emits `Location: /`.
+
+This is the constraint that decided the whole shape of the app: no bundled front end, no client-side
+router, no asset paths. `test_app.py` parses the rendered HTML and fails on any root-relative URL.
+
+### Action routes stay flat because of it
+
+`SELF = './'` is only correct for a route hanging off the root: from `/refresh`, `./` resolves to
+`/`. From `/mode/2` it would resolve to `/mode/`, and the redirect would never reach the page again.
+So an action takes its target in a hidden form field, not in the path.
+
+The root-relative guard does not catch this — `./` does not start with a slash either — so there is
+a separate test asserting the redirect actually lands on the index.
+
+## Views never contact a BOINC client while rendering; actions may
+
+A background thread polls every machine and writes a snapshot; views only read it. Render time does
+not depend on how many machines are configured, and one that is switched off cannot stall the page.
+
+An action is the deliberate exception. It runs its exchange inside the request, with a **five second**
+deadline rather than the thirty the poll gets, because someone is waiting for the page to come back.
+A button press with no confirmation is worse than a slow one — but it is still bounded, and what the
+rule was protecting (rendering) is untouched.
+
+After a successful action the app re-reads **that one machine** over the same connection and swaps it
+into the snapshot. Without it the page comes back looking identical for up to a poll interval, which
+reads as a broken button. Re-reading all of them would put every configured machine back on the
+request path.
+
+## One section per machine, no aggregate table
+
+Cross-machine aggregation was considered and dropped. It was written down as the thing that would
+distinguish this app from `boinctui` and from the HACS integration; what distinguishes it instead is
+that it is graphical and usable from a phone. That is a legitimate answer, just not the one that was
+originally planned — worth knowing before someone re-adds the aggregate view expecting it to be new.
+
+## Only running tasks are listed
+
+`get_results()` returns every task. A machine with a normal work buffer has dozens, which is
+unreadable on a phone, while the ones actually executing number about as many as it has cores. The
+rest are a line of counts. `boinctui` is there for the full queue.
+
+Task rows carry no name: BOINC's identifiers (`LATeah4013L03_925.0_0_0.0_12345_1`) say nothing to a
+reader. The name goes in the row's `title`, where it is still there for anyone who wants to search
+for it in `boinctui`.
+
+## The activity control uses BOINC's own words
+
+The three modes are labelled exactly as BOINC Manager labels them
+(`clientgui/AdvancedFrame.cpp:517-529`), and `boinctui` uses the same three strings
+(`src/topmenu.cpp:89-91`), under a menu both of them call *Activity*:
+
+| request | label | description |
+|---|---|---|
+| `always` | Run always | Allow work regardless of preferences |
+| `auto` | Run based on preferences | Allow work according to preferences |
+| `never` | Suspend | Stop work regardless of preferences |
+
+Copying them costs nothing and means anyone who has used either program recognises the control
+without reading. It also supplies the warning text for `always` — *regardless of preferences* — which
+is more accurate than anything invented here.
+
+BOINC ships translations of all six strings (`locale/es/BOINC-Manager.po`: *Ejecutar siempre*,
+*Ejecutar según preferencias*, *Suspender*). The page itself is not localised — only the
+configuration options in `translations/` are — but if it ever is, that catalogue is where the wording
+should come from rather than a third phrasing of the same idea.
+
+### Stacked, not side by side, and with no radio marks
+
+Each row carries its mode's description. Three of those do not fit across a phone without truncating
+the longest label, and moving the descriptions out to `title` attributes hides the `always` warning
+on exactly the devices that have no pointer to reveal it. BOINC Manager's own *Activity* menu is a
+vertical list of radio items, so stacking is also the original shape.
+
+Radio marks were tried and dropped: with one row filled in, the marks say the same thing twice.
+
+## `always` is not unconditional, and the label must not imply it
+
+`check_suspend_processing` (`client/cs_prefs.cpp:218-300`) tests benchmarks, the startup delay and an
+OS-requested suspend **before** it looks at the mode, so all three suspend a client in `always` too.
+What the mode skips is the user's own preferences: battery, whether the computer is in use, the
+schedule, processor load, exclusive applications.
+
+Observed rather than assumed — a real client in `always` stayed suspended with reason 16, benchmarks.
+
+## Only permanent changes
+
+`set_run_mode` takes a duration: zero makes the change permanent, anything else reverts on its own
+(`RUN_MODE::set`, `client/client_types.cpp:1414`). A timed suspend was designed and then dropped for
+being a second concept to explain in a page whose whole point is that it is glanceable. The RPC still
+takes the duration, so adding it later is a parameter, not a redesign.
+
+## The selected button follows `task_mode_perm`, not `task_mode`
+
+A temporary mode set from BOINC Manager makes the two differ. `task_mode` is what is happening now
+and will revert on its own; `task_mode_perm` is what these buttons set. Marking the temporary one
+would highlight a state this control never chose and cannot restore.
+
+## The header says what is happening, not which mode it is in
+
+It used to append the run mode, which produced *"Computing — computing when its settings allow"*.
+The control shows the mode now, so the header only reports the state and, when suspended, the reason
+BOINC gives.
+
+Expect the reason to lag by about a second after a change: **the mode updates immediately, the
+suspend reason is recomputed on the client's own cycle.** Verified against a running client — it is
+not a bug in the read-back.
+
+## Unreachable and refused are different problems
+
+A machine that is switched off and a machine that is running BOINC but does not allow this app look
+alike at a glance, and need opposite advice. They are told apart by *when* the exchange fails: BOINC
+checks the caller's address only after accepting the connection, so anything that breaks after the
+connection was established means we were let in and then cut off.
+
+Worth keeping because the fix for the second one is specific and otherwise invisible — the machine
+has to add this Home Assistant to its own list of allowed computers.

--- a/boincui/DOCS.md
+++ b/boincui/DOCS.md
@@ -1,8 +1,8 @@
 # Home Assistant BOINC UI App
 
 BOINC UI shows what your BOINC clients are doing — what each machine is computing right now, and the
-projects it is attached to — on a page inside Home Assistant. It is **experimental**, and this
-version can only look: it cannot suspend, resume or abort anything.
+projects it is attached to — on a page inside Home Assistant, and lets you start and stop their
+computing. It is **experimental**. It cannot yet act on individual tasks.
 
 ## Adding a machine
 
@@ -49,15 +49,47 @@ waiting to be sent back. To see the full queue, use the **boinctui** app.
 Each row shows the project, how far along the task is and when it is due. Hovering over a row shows
 BOINC's own name for the task, which is what you would search for in boinctui.
 
+## Starting and stopping a machine
+
+Under **Activity**, each machine has the same three choices BOINC Manager offers, with the same
+names:
+
+- **Run always** — compute regardless of that machine's preferences.
+- **Run based on preferences** — compute when its own settings allow it. This is the usual choice.
+- **Suspend** — stop computing.
+
+Pick one and it takes effect immediately, and stays that way — it survives restarting BOINC and
+restarting the machine, until you or someone else changes it again. The machine's line updates as
+soon as the page comes back.
+
+Two things worth knowing:
+
+**Run always ignores that machine's own rules.** It will keep computing on battery, while you are
+using the computer, and outside the hours you set. On a laptop that means a warm machine and a flat
+battery. It is the right choice for a machine that exists to compute, and the wrong one for the
+laptop you are typing on.
+
+**Run always is not a promise to compute.** A machine can still pause for reasons that are not
+preferences — measuring its own speed after starting up, or the operating system asking it to stop.
+The line above the buttons always says what it is really doing.
+
+If you have suspended a machine from BOINC Manager for a set amount of time, the buttons still show
+its underlying setting, because the timed suspension undoes itself.
+
 ## When something is wrong
 
 Each machine reports its own problem, and the others keep working:
 
-- **Cannot be reached** — wrong address, BOINC not running there, or it has not been told to accept
-  connections from this app.
+- **Cannot be reached** — wrong address, or BOINC is not running there.
+- **Refused the connection** — BOINC is running on that machine, but it is not letting this app in.
+  On that machine, add this Home Assistant to the computers it allows to connect. See *A computer
+  elsewhere on your network* above for which address it will most likely be.
 - **Rejected the password** — the passwords do not match. The BOINC app needs a restart after
   changing its own.
 - **Not fully configured** — that entry is missing its address or password.
+
+If a machine cannot be reached when you press one of the **Activity** buttons, the page says the
+change did not go through and nothing is altered.
 
 The page checks every machine once a minute. **Refresh now** asks for a check straight away instead
 of waiting — the result appears within a few seconds, when the page next reloads.

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "0.4.0"
+version: "0.5.0"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"

--- a/boincui/server/app.py
+++ b/boincui/server/app.py
@@ -2,9 +2,14 @@ import logging
 import threading
 from datetime import datetime, timezone
 
-from flask import Flask, redirect, render_template
+from flask import Flask, redirect, render_template, request
 
-from boinc import read_all
+from boinc import read_all, set_mode
+from status import ACTIVITY_MODES
+
+# The modes a browser is allowed to ask for. Taken from the same table the page renders, so the
+# buttons and what is accepted here cannot drift apart.
+MODE_NAMES = frozenset(key for key, _label, _description in ACTIVITY_MODES)
 
 # Home Assistant serves this app under /api/hassio_ingress/<token>/ and strips that prefix before
 # forwarding, without telling us what it was: the only headers ingress adds are X-Remote-User-* and
@@ -67,14 +72,25 @@ class Snapshot:
             self._machines = machines
             self._updated = datetime.now(timezone.utc)
 
+    def replace(self, index: int, machine: dict) -> None:
+        """Update a single machine, after acting on it.
+
+        Only the one that was acted on changes: re-reading the rest would mean waiting on every
+        configured client inside a request, which is what the background refresher exists to avoid.
+        """
+        with self._lock:
+            if self._machines is not None and 0 <= index < len(self._machines):
+                self._machines[index] = machine
+                self._updated = datetime.now(timezone.utc)
+
 
 class Refresher(threading.Thread):
     """Polls every configured machine on its own thread, so requests never wait on the network."""
 
-    def __init__(self, snapshot: Snapshot, options: dict, stop: threading.Event) -> None:
+    def __init__(self, snapshot: Snapshot, clients: list[dict], stop: threading.Event) -> None:
         super().__init__(name='refresher', daemon=True)
         self._snapshot = snapshot
-        self._clients = clients_from(options)
+        self._clients = clients
         # Not `self._stop`: threading.Thread already uses that name for a private method, and
         # shadowing it makes join() raise TypeError.
         self._stop_requested = stop
@@ -127,13 +143,39 @@ def create_app(snapshot: Snapshot | None = None) -> Flask:
 
     @app.route('/')
     def index():
-        return render_template('index.html', **app.config['SNAPSHOT'].read())
+        return render_template(
+            'index.html',
+            modes=ACTIVITY_MODES,
+            failed=request.args.get('failed', type=int),
+            **app.config['SNAPSHOT'].read(),
+        )
 
     @app.route('/refresh', methods=['POST'])
     def refresh():
         refresher = app.config.get('REFRESHER')
         if refresher is not None:
             refresher.request_refresh()
+        return redirect(SELF)
+
+    # A flat route on purpose. Under `/mode/<machine>` the redirect below would resolve against
+    # `/mode/` and never reach the page again, since the only correct relative target this app can
+    # emit is one that assumes it lives at the root -- see SELF.
+    @app.route('/mode', methods=['POST'])
+    def mode():
+        clients = app.config.get('CLIENTS') or []
+        machine = request.form.get('machine', '')
+        chosen = request.form.get('mode', '')
+        # Both fields come from a browser, so they are checked before anything reaches a client.
+        if not machine.isdigit() or int(machine) >= len(clients) or chosen not in MODE_NAMES:
+            logging.warning(f'Ignoring an activity change for machine {machine!r} to {chosen!r}')
+            return redirect(SELF)
+
+        index = int(machine)
+        updated = set_mode(clients[index], chosen)
+        app.config['SNAPSHOT'].replace(index, updated)
+        if updated['error']:
+            logging.warning(f'{updated["name"]}: {updated["error"]}')
+            return redirect(f'{SELF}?failed={index}')
         return redirect(SELF)
 
     return app

--- a/boincui/server/boinc.py
+++ b/boincui/server/boinc.py
@@ -176,8 +176,13 @@ async def _apply_mode(host: str, port: int, password: str, mode: str) -> dict:
     client = await _open(host, port, password)
     try:
         await _authenticate(client, host, port)
+        # A false return means the client answered <unauthorized/>, the only refusal the library
+        # reports this way. It should not happen after the authentication above succeeded, so if it
+        # ever does the message needs to say what was actually refused rather than invent a cause.
         if not await client.set_run_mode(MODES[mode], PERMANENT):
-            raise AuthenticationFailed('The BOINC client refused to change the mode')
+            raise AuthenticationFailed(
+                'The BOINC client treated the change as unauthorised'
+            )
         # Read back over the same connection, so the page shows the new mode immediately rather
         # than looking unchanged until the next poll. The mode is already updated by the time this
         # returns; the suspend reason may not be, because the client recomputes that on its own

--- a/boincui/server/boinc.py
+++ b/boincui/server/boinc.py
@@ -8,12 +8,22 @@ import asyncio
 import logging
 
 from pyboinc import init_rpc_client
-from status import describe_activity
+from pyboinc.rpc_client import Mode
+from status import describe_activity, describe_mode
 
 DEFAULT_PORT = 31416
 # BOINC's own client gives up well before this; the point is only that a host which accepts the
 # connection and then says nothing cannot hold the refresher forever.
 TIMEOUT_SECONDS = 30
+# Acting on a button press is allowed to touch the network, but not for as long as a poll may: this
+# runs inside a request, with someone waiting for the page to come back.
+ACTION_TIMEOUT_SECONDS = 5
+
+# The mode names this app uses, and the request each one sends.
+MODES = {'always': Mode.ALWAYS, 'auto': Mode.AUTO, 'never': Mode.NEVER}
+# A duration of zero makes the change permanent: it survives a restart of the BOINC client, rather
+# than reverting on its own after a while (`RUN_MODE::set`, client/client_types.cpp:1414).
+PERMANENT = 0
 
 # `active_task_state` when a task is actually executing (lib/common_defs.h: PROCESS_EXECUTING).
 PROCESS_EXECUTING = 1
@@ -31,6 +41,10 @@ class CannotConnect(BoincError):
     pass
 
 
+class ConnectionRejected(BoincError):
+    """The machine answered and then hung up, which means it is running but will not talk to us."""
+
+
 class AuthenticationFailed(BoincError):
     pass
 
@@ -38,6 +52,7 @@ class AuthenticationFailed(BoincError):
 ERROR_KINDS = {
     NotConfigured: 'not_configured',
     CannotConnect: 'cannot_connect',
+    ConnectionRejected: 'rejected',
     AuthenticationFailed: 'auth_failed',
 }
 
@@ -108,49 +123,108 @@ def _summarise(results: list, projects: list) -> dict:
     }
 
 
-async def _collect(host: str, port: int, password: str) -> dict:
-    client = await init_rpc_client(host, password, port)
+async def _open(host: str, port: int, password: str):
+    """Connect, telling a machine that is not there apart from one that will not talk to us.
+
+    BOINC checks the caller's address only after accepting the connection, and hangs up on anyone
+    missing from its allowed list. Both failures look alike from the outside, so they are told apart
+    by *when* they happen: anything after this function returned means we were let in and then cut
+    off, which is a different problem with a different fix.
+    """
     try:
-        # init_rpc_client connects but does not authenticate, and the query methods below do not
-        # check authorisation: against an unauthorised session they return parsed nonsense rather
-        # than failing. Checking the return value here is what turns a wrong password into an error
-        # the page can explain instead of a silently empty screen.
-        if not await client.authorize():
-            raise AuthenticationFailed('The BOINC client rejected the password')
-        cc_status = await client.get_cc_status()
-        projects = _as_list(await client.get_project_status())
-        results = _as_list(await client.get_results())
+        return await init_rpc_client(host, password, port)
+    except (TimeoutError, OSError) as error:
+        raise CannotConnect(f'Could not reach a BOINC client at {host}:{port}') from error
+
+
+async def _authenticate(client, host: str, port: int) -> None:
+    # init_rpc_client connects but does not authenticate, and the query methods do not check
+    # authorisation: against an unauthorised session they return parsed nonsense rather than
+    # failing. Checking the return value here is what turns a wrong password into an error the page
+    # can explain instead of a silently empty screen.
+    try:
+        authorized = await client.authorize()
+    except (asyncio.IncompleteReadError, EOFError, OSError) as error:
+        raise ConnectionRejected(
+            f'The BOINC client at {host}:{port} closed the connection without answering'
+        ) from error
+    if not authorized:
+        raise AuthenticationFailed('The BOINC client rejected the password')
+
+
+async def _read_state(client) -> dict:
+    cc_status = await client.get_cc_status()
+    projects = _as_list(await client.get_project_status())
+    results = _as_list(await client.get_results())
+    return {
+        'activity': describe_activity(cc_status),
+        'mode': describe_mode(cc_status),
+        **_summarise(results, projects),
+    }
+
+
+async def _collect(host: str, port: int, password: str) -> dict:
+    client = await _open(host, port, password)
+    try:
+        await _authenticate(client, host, port)
+        return await _read_state(client)
     finally:
         await client.close()
 
-    return {'activity': describe_activity(cc_status), **_summarise(results, projects)}
+
+async def _apply_mode(host: str, port: int, password: str, mode: str) -> dict:
+    client = await _open(host, port, password)
+    try:
+        await _authenticate(client, host, port)
+        if not await client.set_run_mode(MODES[mode], PERMANENT):
+            raise AuthenticationFailed('The BOINC client refused to change the mode')
+        # Read back over the same connection, so the page shows the new mode immediately rather
+        # than looking unchanged until the next poll. The mode is already updated by the time this
+        # returns; the suspend reason may not be, because the client recomputes that on its own
+        # cycle -- verified against a running client.
+        return await _read_state(client)
+    finally:
+        await client.close()
 
 
-async def _collect_safely(client: dict) -> dict:
+async def _safely(client: dict, action, timeout: int) -> dict:
+    """Run one exchange with a client, turning every way it can fail into a message."""
     host, password = client.get('host'), client.get('password')
     port = client.get('port') or DEFAULT_PORT
     if not host or not password:
         return {'error': NotConfigured('This client is missing an address or a password')}
 
     try:
-        logging.debug(f'Reading state from {host}:{port}')
-        state = await asyncio.wait_for(_collect(host, port, password), TIMEOUT_SECONDS)
-        return {'state': state}
-    except AuthenticationFailed as error:
+        return {'state': await asyncio.wait_for(action(host, port, password), timeout)}
+    except BoincError as error:
         return {'error': error}
-    except (TimeoutError, OSError, ConnectionError) as error:
+    except (TimeoutError, OSError) as error:
         return {'error': CannotConnect(f'Could not reach a BOINC client at {host}:{port}')}
     except Exception as error:
         # The library raises bare exceptions and assertion-style errors on malformed replies, so
         # anything unexpected still has to reach the page as a message rather than kill the poll.
-        logging.debug(f'Unexpected failure reading {host}:{port}: {error!r}')
+        logging.debug(f'Unexpected failure talking to {host}:{port}: {error!r}')
         return {'error': BoincError(f'Unexpected reply from the BOINC client at {host}:{port}')}
+
+
+def _machine(client: dict, outcome: dict) -> dict:
+    """One machine as the page sees it: what it is doing, or what went wrong reaching it."""
+    error = outcome.get('error')
+    return {
+        'name': describe_client(client),
+        'host': client.get('host'),
+        'state': outcome.get('state'),
+        'error': str(error) if error else None,
+        'error_kind': ERROR_KINDS.get(type(error), 'error') if error else None,
+    }
 
 
 async def _read_all(clients: list[dict]) -> list[dict]:
     # Every client is contacted at the same time, so a machine that is switched off delays only
     # itself: a cycle takes as long as the slowest one rather than the sum of all of them.
-    return await asyncio.gather(*(_collect_safely(client) for client in clients))
+    return await asyncio.gather(
+        *(_safely(client, _collect, TIMEOUT_SECONDS) for client in clients)
+    )
 
 
 def read_all(clients: list[dict]) -> list[dict]:
@@ -159,14 +233,23 @@ def read_all(clients: list[dict]) -> list[dict]:
         return []
 
     outcomes = asyncio.run(_read_all(clients))
-    machines = []
-    for client, outcome in zip(clients, outcomes):
-        error = outcome.get('error')
-        machines.append({
-            'name': describe_client(client),
-            'host': client.get('host'),
-            'state': outcome.get('state'),
-            'error': str(error) if error else None,
-            'error_kind': ERROR_KINDS.get(type(error), 'error') if error else None,
-        })
-    return machines
+    return [_machine(client, outcome) for client, outcome in zip(clients, outcomes)]
+
+
+def set_mode(client: dict, mode: str) -> dict:
+    """Change one machine's activity mode, and report how it looks afterwards.
+
+    Returns the same shape as an entry of `read_all`, so the caller can drop it straight into the
+    snapshot. Reaching the machine can fail in all the usual ways and that is reported, not raised;
+    an unknown mode is a mistake in this program and does raise.
+    """
+    if mode not in MODES:
+        raise ValueError(f'Unknown activity mode {mode!r}')
+
+    logging.debug(f'Setting activity mode {mode} on {client.get("host")}')
+    outcome = asyncio.run(_safely(
+        client,
+        lambda host, port, password: _apply_mode(host, port, password, mode),
+        ACTION_TIMEOUT_SECONDS,
+    ))
+    return _machine(client, outcome)

--- a/boincui/server/main.py
+++ b/boincui/server/main.py
@@ -6,7 +6,7 @@ import threading
 
 import waitress
 
-from app import Refresher, Snapshot, create_app
+from app import Refresher, Snapshot, clients_from, create_app
 
 # Supervisor's own default for `ingress_port`, which is why config.yaml does not set it -- the
 # add-on linter rejects redeclaring a default. Home Assistant proxies to this port on the
@@ -56,7 +56,11 @@ if args.exit_immediately:
 else:
     snapshot = Snapshot()
     app = create_app(snapshot)
-    refresher = Refresher(snapshot, options, stop_requested)
+    # Worked out once and shared: calling this twice would log the deprecation warning twice, and
+    # the activity buttons address a machine by its position in this very list.
+    clients = clients_from(options)
+    refresher = Refresher(snapshot, clients, stop_requested)
+    app.config['CLIENTS'] = clients
     # Lets the "refresh now" button poll on demand instead of waiting for the next cycle.
     app.config['REFRESHER'] = refresher
     refresher.start()

--- a/boincui/server/pyboinc/VENDOR.md
+++ b/boincui/server/pyboinc/VENDOR.md
@@ -25,6 +25,18 @@ Only the package is copied — not upstream's tests, `setup.py` or `.travis.yml`
 - **`close()` added** to `_RPCClientRaw` and `RPCClient`. Upstream never closes the connection, so
   anything that polls leaks a socket per cycle and depends on the garbage collector to reap it; BOINC
   also caps concurrent GUI RPC connections. Both additions are marked `LOCAL PATCH` in the source.
+- **`set_run_mode()`, `set_network_mode()` and `set_gpu_mode()` fixed.** All three built the duration
+  element as `ET.SubElement(req, duration)`, passing the *number* where a tag name belongs, so every
+  one of them died with `TypeError: cannot serialize 0 (type int)` before reaching the socket — the
+  whole write path was dead on arrival, which is a fair sign nobody has ever exercised it. Now
+  `ET.SubElement(req, Tag.DURATION)`.
+
+  Neither fork fixes this properly: `Igor-Misic/pyboinc` left it alone, and `SpuelMett/pyboinc` (with
+  the copy inside the HACS integration) changed it to `str(duration)`, which emits `<0>0</0>`. That
+  stops the crash but never sends a duration at all, so BOINC falls back to its default of zero:
+  right by accident for a permanent change, and silently permanent when a temporary one was asked
+  for. The corrected request matches what `boinctui` builds by hand
+  (`src/srvdata.cpp:445`), and was verified against a running BOINC client.
 
 Nothing else is modified.
 
@@ -37,9 +49,9 @@ Nothing else is modified.
   `../boinc.py` calls `authorize()` and checks its return value before querying.
 - `_write()` calls `drain()` before writing instead of after, and the loop in `receive()` is dead
   code because `readuntil` already stops at the separator. Both harmless.
-- The three `set_*_mode()` methods pass a number where `ET.SubElement` wants a tag name. Only
-  affects the write path, which this add-on does not use. Fixed downstream in the HACS integration
-  as `str(duration)` if it is ever needed.
+- Nothing in the library distinguishes a host that is not there from one that accepts the connection
+  and hangs up, which is what BOINC does to a caller missing from its allowed list. `../boinc.py`
+  tells them apart by which stage failed.
 
 ## Upstream is dormant
 

--- a/boincui/server/pyboinc/rpc_client.py
+++ b/boincui/server/pyboinc/rpc_client.py
@@ -209,7 +209,8 @@ class RPCClient:
         """
         req = ET.Element(Tag.SET_RUN_MODE)
         ET.SubElement(req, mode.value)
-        a = ET.SubElement(req, duration)
+        # LOCAL PATCH (not upstream) -- see VENDOR.md
+        a = ET.SubElement(req, Tag.DURATION)
         a.text = str(duration)
         return await self._request_auth(req)
 
@@ -220,7 +221,8 @@ class RPCClient:
         """
         req = ET.Element(Tag.SET_NETWORK_MODE)
         ET.SubElement(req, mode.value)
-        a = ET.SubElement(req, duration)
+        # LOCAL PATCH (not upstream) -- see VENDOR.md
+        a = ET.SubElement(req, Tag.DURATION)
         a.text = str(duration)
         return await self._request_auth(req)
 
@@ -231,6 +233,7 @@ class RPCClient:
         """
         req = ET.Element(Tag.SET_GPU_MODE)
         ET.SubElement(req, mode.value)
-        a = ET.SubElement(req, duration)
+        # LOCAL PATCH (not upstream) -- see VENDOR.md
+        a = ET.SubElement(req, Tag.DURATION)
         a.text = str(duration)
         return await self._request_auth(req)

--- a/boincui/server/status.py
+++ b/boincui/server/status.py
@@ -36,23 +36,48 @@ RUN_MODE_ALWAYS = 1
 RUN_MODE_AUTO = 2
 RUN_MODE_NEVER = 3
 
-RUN_MODES = {
-    RUN_MODE_ALWAYS: 'always computing',
-    RUN_MODE_AUTO: 'computing when its settings allow',
-    RUN_MODE_NEVER: 'set never to compute',
+# What each mode is called on screen. The three labels and their descriptions are copied verbatim
+# from BOINC's own Activity menu (`clientgui/AdvancedFrame.cpp:517-529`); `boinctui` uses the same
+# three strings (`src/topmenu.cpp:89-91`). Anyone who has used either recognises this control.
+ACTIVITY_MODES = (
+    ('always', 'Run always', 'Allow work regardless of preferences'),
+    ('auto', 'Run based on preferences', 'Allow work according to preferences'),
+    ('never', 'Suspend', 'Stop work regardless of preferences'),
+)
+
+MODE_KEYS = {
+    RUN_MODE_ALWAYS: 'always',
+    RUN_MODE_AUTO: 'auto',
+    RUN_MODE_NEVER: 'never',
 }
 
 
 def describe_activity(cc_status: dict | None) -> str:
-    """One line saying whether the client is computing, and if not, why not."""
+    """One line saying whether the client is computing, and if not, why not.
+
+    Deliberately silent about the run mode: the activity control on the page already shows it, and
+    saying it here as well produced the likes of "Computing — computing when its settings allow".
+    """
     if not cc_status:
         return 'Unknown'
 
-    mode = cc_status.get('task_mode')
     reason = cc_status.get('task_suspend_reason') or 0
-
     if reason:
         return f'Paused — {SUSPEND_REASONS.get(reason, "BOINC did not say why")}'
-    if mode == RUN_MODE_NEVER:
-        return 'Paused — set never to compute'
-    return f'Computing — {RUN_MODES.get(mode, "running")}'
+    if cc_status.get('task_mode') == RUN_MODE_NEVER:
+        # Reached only in the moment between setting the mode and the client recomputing its
+        # suspend reason, which it does on its own cycle rather than when the mode is set.
+        return 'Paused — someone asked it to stop'
+    return 'Computing'
+
+
+def describe_mode(cc_status: dict | None) -> str | None:
+    """Which activity mode the buttons should show as selected.
+
+    Reads `task_mode_perm`, not `task_mode`: a temporary mode set from BOINC Manager makes the two
+    differ, and the temporary one reverts on its own, so marking it would highlight a state this
+    control never set and cannot restore.
+    """
+    if not cc_status:
+        return None
+    return MODE_KEYS.get(cc_status.get('task_mode_perm'))

--- a/boincui/server/templates/index.html
+++ b/boincui/server/templates/index.html
@@ -48,11 +48,50 @@
     font: inherit;
     padding: 0.4rem 0.9rem;
   }
+  .activity { margin: 0 0 0.9rem; }
+  .activity-label {
+    display: block;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.3rem;
+    opacity: 0.6;
+    text-transform: uppercase;
+  }
+  /* Stacked rather than side by side: each mode carries BOINC's own description, and three of
+     those do not fit across a phone without truncating the one that most needs reading. */
+  .modes {
+    border: 1px solid currentColor;
+    border-radius: 0.375rem;
+    display: flex;
+    flex-direction: column;
+    max-width: 27rem;
+    overflow: hidden;
+  }
+  .modes button {
+    border: 0;
+    border-bottom: 1px solid currentColor;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.5rem 0.8rem 0.55rem;
+    text-align: left;
+    width: 100%;
+  }
+  .modes button:last-child { border-bottom: 0; }
+  .modes button small { font-size: 0.78rem; opacity: 0.7; }
+  /* Canvas is the page's own background, so the selected row reads correctly in light and dark
+     without this file having to know which one it is in. */
+  .modes button[aria-pressed="true"] { background: currentColor; }
+  .modes button[aria-pressed="true"] span,
+  .modes button[aria-pressed="true"] small { color: Canvas; }
+  .modes button[aria-pressed="true"] small { opacity: 0.85; }
 </style>
 </head>
 <body>
 <h1>BOINC UI</h1>
-<p class="muted">Experimental. Shows what your BOINC clients are doing; it cannot change anything.</p>
+<p class="muted">Experimental. Shows what your BOINC clients are doing, and lets you start and stop
+their computing.</p>
 
 {% if machines is none %}
 <div class="card">
@@ -75,10 +114,19 @@
   <div class="machine{% if machine.error %} problem{% endif %}">
     <h2>{{ machine.name }}</h2>
 
+    {% if failed == loop.index0 %}
+    <p class="status"><strong>That change did not go through.</strong></p>
+    {% endif %}
+
     {% if machine.error_kind == 'cannot_connect' %}
     <p class="status"><strong>Cannot be reached.</strong> {{ machine.error }}</p>
     <p class="muted">Check the address, that BOINC is running there, and that it is allowed to
     accept connections from this app.</p>
+
+    {% elif machine.error_kind == 'rejected' %}
+    <p class="status"><strong>Refused the connection.</strong></p>
+    <p class="muted">BOINC is running on that machine, but it is not letting this app in. On that
+    machine, add this Home Assistant to the computers allowed to connect to it.</p>
 
     {% elif machine.error_kind == 'auth_failed' %}
     <p class="status"><strong>Rejected the password.</strong></p>
@@ -92,6 +140,21 @@
 
     {% else %}
     <p class="status">{{ machine.state.activity }}</p>
+
+    <form method="post" action="mode" class="activity">
+      <input type="hidden" name="machine" value="{{ loop.index0 }}">
+      <span class="activity-label">Activity</span>
+      <div class="modes">
+        {% for key, label, description in modes %}
+        <button type="submit" name="mode" value="{{ key }}"
+                aria-pressed="{{ 'true' if machine.state.mode == key else 'false' }}">
+          <span>{{ label }}</span>
+          <small>{{ description }}</small>
+        </button>
+        {% endfor %}
+      </div>
+    </form>
+
     <p class="counts">
       {{ machine.state.running | length }} running ·
       {{ machine.state.queued }} waiting ·

--- a/boincui/server/test/test_app.py
+++ b/boincui/server/test/test_app.py
@@ -4,6 +4,7 @@ import unittest
 from datetime import datetime, timedelta
 from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import urljoin
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -17,7 +18,8 @@ URL_ATTRIBUTES = ('href', 'src', 'action', 'formaction')
 
 
 def machine(name='pc', error=None, error_kind=None, running=(), queued=0, ready=0,
-            projects=(('Example Project', 'https://example.org/'),), activity='Computing — always computing'):
+            projects=(('Example Project', 'https://example.org/'),), activity='Computing',
+            mode='auto'):
     return {
         'name': name,
         'host': 'pc.local',
@@ -25,6 +27,7 @@ def machine(name='pc', error=None, error_kind=None, running=(), queued=0, ready=
         'error_kind': error_kind,
         'state': None if error else {
             'activity': activity,
+            'mode': mode,
             'running': list(running),
             'queued': queued,
             'ready_to_report': ready,
@@ -61,9 +64,28 @@ class UrlCollector(HTMLParser):
                 self.urls.append((tag, name, value))
 
 
-def client_for(snapshot):
+class ModeButtonCollector(HTMLParser):
+    """The activity buttons as {mode: whether it is shown as the current one}."""
+
+    def __init__(self):
+        super().__init__()
+        self.buttons = {}
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == 'button' and attrs.get('name') == 'mode':
+            self.buttons[attrs.get('value')] = attrs.get('aria-pressed')
+
+
+def modes_in(page):
+    collector = ModeButtonCollector()
+    collector.feed(page)
+    return collector.buttons
+
+
+def client_for(snapshot, clients=None):
     app = create_app(snapshot)
-    app.config.update(TESTING=True)
+    app.config.update(TESTING=True, CLIENTS=clients if clients is not None else [])
     return app.test_client()
 
 
@@ -260,6 +282,99 @@ class TestRefreshButton(unittest.TestCase):
         self.assertEqual(302, client_for(Snapshot()).post('/refresh').status_code)
 
 
+class TestActivityControl(unittest.TestCase):
+    """The three-way control, and the route behind it."""
+
+    def page_with(self, **kwargs):
+        return client_for(snapshot_of(machine(**kwargs))).get('/').get_data(as_text=True)
+
+    def test_should_offer_the_three_modes_boinc_itself_names(self):
+        page = self.page_with()
+
+        for label in ('Run always', 'Run based on preferences', 'Suspend'):
+            self.assertIn(label, page)
+        self.assertIn('Allow work regardless of preferences', page)
+
+    def test_should_mark_the_mode_the_machine_is_actually_in(self):
+        self.assertEqual(
+            {'always': 'false', 'auto': 'false', 'never': 'true'},
+            modes_in(self.page_with(mode='never')),
+        )
+
+    def test_should_not_offer_the_control_for_a_machine_it_cannot_read(self):
+        # There is nothing to act on, and the buttons would only mislead.
+        page = self.page_with(error='boom', error_kind='cannot_connect')
+
+        self.assertEqual({}, modes_in(page))
+
+    def test_should_explain_a_connection_that_was_refused_rather_than_absent(self):
+        page = self.page_with(error='hung up', error_kind='rejected')
+
+        self.assertIn('Refused the connection', page)
+        self.assertIn('allowed to connect', page)
+
+
+class TestModeRoute(unittest.TestCase):
+
+    def setUp(self):
+        self.calls = []
+        self.original = app_module.set_mode
+        app_module.set_mode = lambda client, mode: (
+            self.calls.append((client, mode)) or machine(name='pc', mode=mode)
+        )
+        self.addCleanup(setattr, app_module, 'set_mode', self.original)
+
+    def post(self, snapshot=None, clients=None, **data):
+        snapshot = snapshot if snapshot is not None else snapshot_of(machine())
+        clients = clients if clients is not None else [{'host': 'pc.local', 'password': 'x'}]
+        return client_for(snapshot, clients).post('/mode', data=data)
+
+    def test_should_change_the_mode_of_the_machine_that_was_asked_for(self):
+        response = self.post(machine='0', mode='never')
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual([({'host': 'pc.local', 'password': 'x'}, 'never')], self.calls)
+
+    def test_should_show_the_new_state_without_waiting_for_the_next_poll(self):
+        # Otherwise the page comes back looking exactly as before and the button reads as broken.
+        snapshot = snapshot_of(machine(mode='auto'))
+        self.post(snapshot=snapshot, machine='0', mode='never')
+
+        self.assertEqual('never', snapshot.read()['machines'][0]['state']['mode'])
+
+    def test_should_redirect_back_to_the_page_and_not_alongside_it(self):
+        # A nested route such as /mode/0 would make this same './' resolve to /mode/, which is why
+        # the machine travels in the form instead of the path. The root-relative guard elsewhere
+        # cannot catch this: './' does not start with a slash either.
+        response = self.post(machine='0', mode='never')
+
+        self.assertEqual('/', urljoin('/mode', response.headers['Location']))
+
+    def test_should_point_at_the_machine_that_could_not_be_changed(self):
+        app_module.set_mode = lambda client, mode: machine(
+            name='pc', error='hung up', error_kind='rejected')
+        response = self.post(machine='0', mode='never')
+
+        self.assertEqual('/?failed=0', urljoin('/mode', response.headers['Location']))
+
+    def test_should_say_so_on_the_page_when_a_change_did_not_go_through(self):
+        page = client_for(snapshot_of(machine(error='hung up', error_kind='rejected'))) \
+            .get('/?failed=0').get_data(as_text=True)
+
+        self.assertIn('did not go through', page)
+
+    def test_should_refuse_anything_the_browser_made_up(self):
+        for data in ({'machine': '7', 'mode': 'never'},      # no such machine
+                     {'machine': 'all', 'mode': 'never'},    # not a number
+                     {'machine': '0', 'mode': 'turbo'},      # not a mode
+                     {}):                                    # nothing at all
+            with self.subTest(data=data):
+                response = self.post(**data)
+
+                self.assertEqual(302, response.status_code)
+                self.assertEqual([], self.calls, 'a made-up request reached a BOINC client')
+
+
 class TestRefresher(unittest.TestCase):
 
     def test_should_poll_again_promptly_when_a_refresh_is_requested(self):
@@ -269,7 +384,7 @@ class TestRefresher(unittest.TestCase):
         original = app_module.read_all
         app_module.read_all = lambda clients: polls.release() or []
         stop = threading.Event()
-        refresher = Refresher(Snapshot(), {}, stop)
+        refresher = Refresher(Snapshot(), [], stop)
         try:
             refresher.start()
             self.assertTrue(polls.acquire(timeout=10), 'the refresher never polled on startup')

--- a/boincui/server/test/test_boinc.py
+++ b/boincui/server/test/test_boinc.py
@@ -129,6 +129,10 @@ class FakeBoincClient:
         if self.rejects:
             self.connections_closed += 1
             writer.close()
+            # Waiting for the transport to finish closing, rather than returning on a half-closed
+            # one, which some Python versions report as a ResourceWarning that looks like a leak in
+            # the code under test.
+            await writer.wait_closed()
             return
         try:
             while True:

--- a/boincui/server/test/test_boinc.py
+++ b/boincui/server/test/test_boinc.py
@@ -9,7 +9,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import boinc  # noqa: E402
-from boinc import read_all  # noqa: E402
+from boinc import read_all, set_mode  # noqa: E402
+
+MODE_VALUES = {'always': 1, 'auto': 2, 'never': 3}
 
 END = b'\x03'
 PASSWORD = 'correct horse'
@@ -55,8 +57,9 @@ NO_PROJECTS = '<boinc_gui_rpc_reply>\n<projects>\n</projects>\n</boinc_gui_rpc_r
 NO_TASKS = results_reply()
 
 
-def cc_status(mode=2, suspend_reason=0):
+def cc_status(mode=2, suspend_reason=0, perm=None):
     return (f'<boinc_gui_rpc_reply>\n<cc_status>\n<task_mode>{mode}</task_mode>\n'
+            f'<task_mode_perm>{mode if perm is None else perm}</task_mode_perm>\n'
             f'<task_suspend_reason>{suspend_reason}</task_suspend_reason>\n'
             '</cc_status>\n</boinc_gui_rpc_reply>')
 
@@ -68,11 +71,15 @@ class FakeBoincClient:
     and <auth2> is accepted only when it carries md5(nonce + password).
     """
 
-    def __init__(self, password=PASSWORD, tasks=None, projects=PROJECTS, status=None):
+    def __init__(self, password=PASSWORD, tasks=None, projects=PROJECTS, status=None, rejects=False):
         self.password = password
         self.tasks = tasks if tasks is not None else results_reply(running_task())
         self.projects = projects
         self.status = status if status is not None else cc_status()
+        # A client that accepts the connection and then hangs up, which is what BOINC does to a
+        # caller missing from its allowed list -- it checks the address only after accepting.
+        self.rejects = rejects
+        self.requests = []
         self.connections_seen = 0
         self.connections_closed = 0
         self._server = None
@@ -112,13 +119,21 @@ class FakeBoincClient:
         self.port = self._server.sockets[0].getsockname()[1]
         ready.set()
         self._loop.run_forever()
+        # Without this the interpreter reports an unclosed event loop per server, which reads like a
+        # leak in the code under test rather than in this double.
+        self._loop.close()
 
     async def _handle(self, reader, writer):
         self.connections_seen += 1
         nonce = '1234567890'
+        if self.rejects:
+            self.connections_closed += 1
+            writer.close()
+            return
         try:
             while True:
                 request = (await reader.readuntil(END)).decode('ISO-8859-1')
+                self.requests.append(request)
                 if '<auth1' in request:
                     reply = f'<boinc_gui_rpc_reply>\n<nonce>{nonce}</nonce>\n</boinc_gui_rpc_reply>'
                 elif '<auth2' in request:
@@ -131,6 +146,13 @@ class FakeBoincClient:
                     reply = self.projects
                 elif '<get_results' in request:
                     reply = self.tasks
+                elif '<set_run_mode' in request:
+                    # Answering <success/> is not enough: the client really does change what it
+                    # reports, and the page reads that back over the same connection.
+                    for name, value in MODE_VALUES.items():
+                        if f'<{name} ' in request or f'<{name}/' in request:
+                            self.status = cc_status(mode=value)
+                    reply = '<boinc_gui_rpc_reply>\n<success/>\n</boinc_gui_rpc_reply>'
                 else:
                     reply = '<boinc_gui_rpc_reply>\n<unauthorized/>\n</boinc_gui_rpc_reply>'
                 writer.write(reply.encode('ISO-8859-1') + END)
@@ -296,6 +318,91 @@ class TestSeveralClients(unittest.TestCase):
 
     def test_should_return_nothing_when_no_client_is_configured(self):
         self.assertEqual([], read_all([]))
+
+
+class TestActivityMode(unittest.TestCase):
+    """Changing a machine's activity mode -- the only thing this app writes."""
+
+    def test_should_send_exactly_the_request_the_client_expects(self):
+        # The vendored library passed the duration as an element *name*, so this request never
+        # reached the wire at all. boinctui builds the same message by hand (src/srvdata.cpp:445),
+        # and a real client was verified to accept this one and change mode.
+        with FakeBoincClient() as server:
+            set_mode(server.as_client('machine'), 'never')
+            sent = ''.join(server.requests)
+
+        self.assertIn('<set_run_mode><never/><duration>0</duration></set_run_mode>', sent)
+
+    def test_should_ask_for_a_permanent_change(self):
+        # A non-zero duration would revert on its own; this app only offers changes that stick.
+        with FakeBoincClient() as server:
+            set_mode(server.as_client('machine'), 'auto')
+            sent = ''.join(server.requests)
+
+        self.assertIn('<duration>0</duration>', sent)
+
+    def test_should_report_the_mode_the_client_settled_on(self):
+        for mode in ('always', 'auto', 'never'):
+            with self.subTest(mode=mode):
+                with FakeBoincClient() as server:
+                    machine = set_mode(server.as_client('machine'), mode)
+
+                self.assertIsNone(machine['error'])
+                self.assertEqual(mode, machine['state']['mode'])
+
+    def test_should_read_the_whole_machine_back_so_the_page_can_show_it(self):
+        # The page swaps this straight into its snapshot, so it has to be a complete entry rather
+        # than just the new mode.
+        with FakeBoincClient() as server:
+            machine = set_mode(server.as_client('machine'), 'never')
+
+        self.assertEqual('machine', machine['name'])
+        self.assertEqual(1, len(machine['state']['running']))
+        self.assertEqual(['Example Project'], [p['name'] for p in machine['state']['projects']])
+
+    def test_should_follow_the_permanent_mode_not_a_temporary_one(self):
+        # A temporary mode set from BOINC Manager reverts on its own, so highlighting it would mark
+        # a state these buttons never set and cannot restore.
+        with FakeBoincClient(status=cc_status(mode=3, perm=2)) as server:
+            machine = read_all([server.as_client('machine')])[0]
+
+        self.assertEqual('auto', machine['state']['mode'])
+
+    def test_should_report_a_wrong_password_without_changing_anything(self):
+        with FakeBoincClient() as server:
+            machine = dict(server.as_client('machine'), password='wrong password')
+            outcome = set_mode(machine, 'never')
+            sent = ''.join(server.requests)
+
+        self.assertEqual('auth_failed', outcome['error_kind'])
+        self.assertNotIn('set_run_mode', sent)
+
+    def test_should_report_a_machine_that_cannot_be_reached(self):
+        client = {'name': 'off', 'host': '127.0.0.1', 'port': refused_port(), 'password': PASSWORD}
+
+        self.assertEqual('cannot_connect', set_mode(client, 'never')['error_kind'])
+
+    def test_should_refuse_a_mode_it_does_not_know(self):
+        # Not a network problem -- a mistake in this program, which should not be dressed up as one.
+        with self.assertRaises(ValueError):
+            set_mode({'host': '127.0.0.1', 'password': PASSWORD}, 'turbo')
+
+
+class TestRejectedConnection(unittest.TestCase):
+    """A machine that is switched off and one that will not talk to us need different advice."""
+
+    def test_should_tell_a_refused_connection_apart_from_an_absent_machine(self):
+        with FakeBoincClient(rejects=True) as server:
+            machine = read_all([server.as_client('guarded')])[0]
+
+        self.assertEqual('rejected', machine['error_kind'])
+        self.assertIn('closed the connection', machine['error'])
+
+    def test_should_say_the_same_when_acting_on_it(self):
+        with FakeBoincClient(rejects=True) as server:
+            machine = set_mode(server.as_client('guarded'), 'never')
+
+        self.assertEqual('rejected', machine['error_kind'])
 
 
 if __name__ == '__main__':

--- a/docs/boincui/DEVELOPMENT.md
+++ b/docs/boincui/DEVELOPMENT.md
@@ -1,0 +1,1 @@
+../../boincui/DEVELOPMENT.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,4 +26,5 @@ nav:
   - BOINC UI Add-on:
       - Overview: boincui/README.md
       - Documentation: boincui/DOCS.md
+      - Development: boincui/DEVELOPMENT.md
       - Changelog: boincui/CHANGELOG.md


### PR DESCRIPTION
Sojourner and Snoopy show up on my own install as *"someone asked it to stop"* — which is exactly `RUN_MODE_NEVER` — and the only way to start them again was `boinctui` or walking to the machine. The page showed the problem and would not let you fix it.

Each machine now gets an **Activity** control with the same three choices BOINC Manager offers, under a menu both it and `boinctui` call *Activity*:

| request | label | description |
|---|---|---|
| `always` | Run always | Allow work regardless of preferences |
| `auto` | Run based on preferences | Allow work according to preferences |
| `never` | Suspend | Stop work regardless of preferences |

Copied verbatim from `clientgui/AdvancedFrame.cpp:517-529`; `boinctui` uses the same strings in `src/topmenu.cpp:89-91`. It costs nothing and means anyone who has used either recognises the control — and it supplies the warning for `always` (*regardless of preferences*) more accurately than anything invented here.

## The vendored library could not do this at all

All three `set_*_mode()` methods pass the duration where a tag name belongs:

```python
a = ET.SubElement(req, duration)   # duration is an int
```

Every one raised `TypeError: cannot serialize 0 (type int)` before reaching the socket. The whole write path was dead on arrival, which is a fair sign nobody has ever run it.

Neither fork fixes it properly. `Igor-Misic/pyboinc` left it alone; `SpuelMett/pyboinc` and the copy inside the HACS integration changed it to `str(duration)`, which emits `<0>0</0>` — it stops the crash but **never sends a duration**, so BOINC falls back to zero. Right by accident for a permanent change, and silently permanent when a timed one was asked for.

The fix here is `ET.SubElement(req, Tag.DURATION)`, which produces the same message `boinctui` builds by hand (`src/srvdata.cpp:445`). Recorded in `VENDOR.md` as the second local patch, and noted in `TODO.md` as a three-line PR for whenever the PyPI fork happens.

## Rendering still never touches the network

An action is the deliberate exception, with a **5 s** deadline rather than the poll's 30, because a button press with no confirmation is worse than a slow one. On success only the acted-on machine is re-read, over the same connection, so the page does not come back looking identical for a whole poll interval.

The route is flat rather than `/mode/<n>`: from a nested path the relative redirect would resolve to `/mode/` and never reach the page again. The existing root-relative guard cannot catch that — `./` does not start with a slash either — so there is a separate test asserting the redirect lands on the index.

## Unreachable vs refused

A machine that is switched off and one that is running BOINC but will not let us in look alike and need opposite fixes. They are told apart by which stage failed: BOINC checks the caller's address only *after* accepting the connection.

## Verified against a real BOINC client, not just the double

- The three modes, each cross-checked with `boinccmd --get_cc_status`.
- The rejection path provoked for real — the client logged `GUI RPC request from non-allowed address 192.168.65.1`, the Docker gateway rather than the caller, which also turns a long-standing `TODO.md` inference into evidence.
- **`always` is not unconditional**: a real client in `always` stayed suspended with reason 16, benchmarks — the pre-mode gate in `client/cs_prefs.cpp:218-300`, observed rather than assumed.
- **The mode updates immediately; the suspend reason lags** by about a second, because the client recomputes it on its own cycle. Commented in the code, since it otherwise reads as a bug in the read-back.
- Under a real Supervisor: two machines configured, `POST` changes the mode and the `boinc` add-on confirms it independently; a dead machine redirects to `?failed=1` without disturbing the other.
- 63 tests green, including inside the image on Python 3.13.5.

Not verified: the ingress proxy hop itself — creating an ingress session needs a Home Assistant user token, and the Supervisor token gets a 401. `/mode` is structurally identical to `/refresh`, which has been in production since 0.3.0.

## Documentation

`boincui/DEVELOPMENT.md` is new and records the UI/UX decisions with their reasoning and evidence — why server-side rendering, the route-depth trap, why no aggregate table, running tasks only, BOINC's vocabulary, vertical without radio marks, permanent-only changes. `CLAUDE.md` links to it so it gets read before the page changes and extended when something new is decided.

It also corrects `CLAUDE.md` on how the docs site is assembled: the nav does not reach into add-on directories, `docs/` is full of symlinks. `mkdocs --strict` failed until the symlink existed.

## Deliberately not in this release

The three deprecated single-client options stay. `TODO.md` had them down for 0.5.0, but they have been deprecated for a single published version and Supervisor discards removed options **silently**, so anyone who had not migrated would lose their configuration without warning. Moved to 0.6.0, with the reason recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP