### PR TITLE
feat(boincui)!: 1.0.0, no longer experimental

### DIFF
--- a/.claude/skills/run-boinc-addons/SKILL.md
+++ b/.claude/skills/run-boinc-addons/SKILL.md
@@ -187,6 +187,14 @@ Gotchas.
   5. Restarting `hassio_supervisor` by hand loses `/run/supervisor`, after which
      Home Assistant Core fails to start with `bind source path does not exist`.
      `mkdir -p /run/supervisor` before rebooting Supervisor fixes it.
+  6. **`docker stop hassio_supervisor` takes the devcontainer's own Docker daemon
+     down with it.** `supervisor_run` runs under `set -e`, so the container it was
+     waiting on exiting ends the script and `dockerd` with it; `ha-addons-dev` stays
+     `Up` while every `docker` call inside it fails with `dial unix
+     /var/run/docker.sock: connect: no such file or directory`, and the whole hassio
+     stack is gone. `docker restart ha-addons-dev` alone does **not** bring it back —
+     re-run `supervisor.sh up`, which is idempotent and recovers in about a minute
+     since the images are already in the volume. Use `restart`, never `stop`.
 - **An installed add-on's metadata is a snapshot.** Supervisor stores the parsed
   `config.yaml`/`translations` in `/mnt/supervisor/apps.json` at install time, so
   `ha apps info` keeps serving the old values after you edit those files — even

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ Three independent Home Assistant add-ons, each self-contained with its own `conf
   a BOINC client, and `main.py` runs it under waitress and owns the process lifecycle.
   `--exit-immediately` is the one-shot path used by CI; otherwise it blocks until signalled, because
   an entrypoint that returns leaves Supervisor reporting the app as stopped seconds after the user
-  started it. `config.yaml` declares `stage: experimental`, which also suppresses its Bluesky release
-  announcement (see CI section).
+  started it. It declared `stage: experimental` until 1.0.0, which also suppressed its Bluesky
+  release announcement; like the other two it now leaves `stage` unset, which Supervisor reads as
+  `stable` (see CI section).
 
   Three rules that are easy to break, all covered by tests:
   1. **Every emitted URL must be relative** — ingress strips its prefix and does not pass it on (see

--- a/TODO.md
+++ b/TODO.md
@@ -39,10 +39,10 @@ Resolved.
 Reviewed against <https://developers.home-assistant.io/docs/apps/> (fetched 2026-08-08), plus
 findings measured directly against the Supervisor in `.devcontainer`.
 
-- [ ] **`icon.png` violates the documented 1x1 aspect ratio in both add-ons.** `boinc/icon.png` and
-  `boinctui/icon.png` are byte-identical and **256 x 245**, so they are letterboxed or distorted in
-  the store. `logo.png` at 600x305 is fine — the docs explicitly allow other logo ratios. Padding to
-  256 x 256 with transparency (not rescaling) is the fix.
+- [x] **`icon.png` aspect ratio — no longer an issue.** Re-measured 2026-08-11: `boinc/icon.png`,
+  `boinctui/icon.png` and `boincui/icon.png` are byte-identical and **256 x 256**, so the 1x1 rule is
+  met. The earlier note recording 256 x 245 was wrong or has been overtaken. `logo.png` at 600x305 is
+  fine either way — the docs explicitly allow other logo ratios.
   `docs/icon.png` is a symlink to `boinc/icon.png` and follows automatically.
 
 - [ ] **`map:` uses the legacy plain-string form.** `boinc/config.yaml` has `map: [addon_config]`,
@@ -215,12 +215,13 @@ Common BOINC global preferences not exposed, each roughly one key away in
 
 - [ ] **Prometheus metrics endpoint** — same data source, different consumer.
 
-- [ ] **Remove `boincui`'s deprecated single-client options in 0.6.0** — `boinc_host`, `boinc_port`
-  and `gui_rpc_password`, replaced by the `clients` list in 0.4.0. Held back from 0.5.0 on purpose:
-  they had been deprecated for a single released version, and Supervisor **silently discards options
-  that disappear from the schema**, so anyone who had not migrated would lose their configuration
-  with no warning. `clients_from` in `app.py` is the whole migration; deleting it also means dropping
-  the three entries from `translations/*.yaml` and the *Upgrading* section of `DOCS.md`.
+- [x] **`boincui`'s deprecated single-client options removed — in 1.0.0, not 0.6.0.** Held back from
+  0.5.0 because they had been deprecated for a single released version and Supervisor **silently
+  discards options that disappear from the schema**. Brought forward to 1.0.0 rather than pushed
+  further out, because that release also drops `stage: experimental`: once an add-on is stable,
+  removing an option from its schema is a breaking change that would call for a 2.0, so 1.0 was the
+  last cheap moment. The landing is soft — an unmigrated install starts with no machines and the page
+  says exactly that — and the `CHANGELOG.md` entry warns before the update.
 
 - [ ] **Localise `boincui`'s page.** Only `translations/*.yaml` is translated today, and that covers
   configuration fields, not the page itself. If it is ever done, the activity control's wording

--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0
+
+The three old settings for a single BOINC client — address, port and password — are gone. If you are still using them instead of the BOINC clients list, this update leaves the app with no machines configured and the page will tell you so; add them to the list and it works again. If you already use the list, nothing changes
+
+BOINC UI is no longer marked as experimental
+
 ## 0.5.0
 
 You can now start and stop computing on each machine, under Activity: Run always, Run based on preferences, or Suspend. They are the same three choices, with the same names, that BOINC Manager offers

--- a/boincui/DOCS.md
+++ b/boincui/DOCS.md
@@ -2,7 +2,7 @@
 
 BOINC UI shows what your BOINC clients are doing — what each machine is computing right now, and the
 projects it is attached to — on a page inside Home Assistant, and lets you start and stop their
-computing. It is **experimental**. It cannot yet act on individual tasks.
+computing. It cannot yet act on individual tasks.
 
 ## Adding a machine
 
@@ -94,8 +94,3 @@ change did not go through and nothing is altered.
 The page checks every machine once a minute. **Refresh now** asks for a check straight away instead
 of waiting — the result appears within a few seconds, when the page next reloads.
 
-## Upgrading from an earlier version
-
-If you configured a single client before this version, it keeps working and appears as one machine.
-Move those settings into the **BOINC clients** list when convenient: the old fields are marked as old
-settings and will stop working in a future version.

--- a/boincui/README.md
+++ b/boincui/README.md
@@ -5,17 +5,17 @@
 
 ## About
 
-BOINC UI will be a graphical web interface for monitoring and controlling the BOINC client from
-your browser, as an alternative to the text mode interface the boinctui app provides.
+BOINC UI is a graphical web interface for monitoring and controlling the BOINC client from your
+browser, as an alternative to the text mode interface the boinctui app provides.
 
 ## Status
 
 It opens a page inside Home Assistant showing what each of your BOINC machines is computing and the
 projects it is attached to — the BOINC app on this machine, other computers on your network, or
-both.
+both. Each machine can be set to compute always, to follow its own preferences, or to stop.
 
-This app is **experimental and read-only**: it can show you what BOINC is doing, but not change it.
-Use the **boinctui** app to suspend tasks, attach projects or anything else.
+It does not yet act on individual tasks, attach or detach projects, or change a machine's
+preferences. Use the **boinctui** app for those.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "0.5.0"
+version: "1.0.0"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"
@@ -9,11 +9,10 @@ arch:
 init: false
 ingress: true
 panel_icon: mdi:chart-box
-stage: experimental
 # A list-of-dict option cannot be marked optional: Supervisor's check for missing options only
 # honours a trailing "?" on a string, and for a list it looks at the first element, which here is a
 # dict (apps/options.py, _check_missing_options). Without this default an empty configuration fails
-# validation, so neither a fresh install nor an upgrade from 0.3.0 would start.
+# validation, so a fresh install would not start.
 options:
   clients: []
 schema:
@@ -22,11 +21,6 @@ schema:
       host: "str"
       port: "port?"
       password: "password"
-  # Replaced by the list above. Kept for one version so that upgrading does not silently discard an
-  # existing configuration: Supervisor drops options that are missing from the schema without asking.
-  boinc_host: "str?"
-  boinc_port: "port?"
-  gui_rpc_password: "password?"
 image: "ghcr.io/hectorespert/addon-boincui"
 apparmor: false
 backup: cold

--- a/boincui/server/app.py
+++ b/boincui/server/app.py
@@ -25,29 +25,13 @@ REFRESH_SECONDS = 60
 
 
 def clients_from(options: dict) -> list[dict]:
-    """The machines to poll, accepting the single-client options this add-on used to have.
+    """The machines to poll.
 
-    Supervisor drops options that are absent from the schema without telling anyone, so removing the
-    old keys outright would silently wipe an existing configuration. They keep working for one
-    version instead.
+    The single-client options this add-on started with (`boinc_host` and friends) were removed in
+    1.0.0 and are deliberately not read any more: Supervisor discards options that are missing from
+    the schema, so they cannot arrive here even if someone still has them configured.
     """
-    clients = options.get('clients') or []
-    if clients:
-        return clients
-
-    if options.get('boinc_host') or options.get('gui_rpc_password'):
-        logging.warning(
-            'Using the old single-client options. Move them to the "clients" list in the '
-            'Configuration tab; they will stop working in a future version'
-        )
-        return [{
-            'name': options.get('boinc_host'),
-            'host': options.get('boinc_host'),
-            'port': options.get('boinc_port'),
-            'password': options.get('gui_rpc_password'),
-        }]
-
-    return []
+    return options.get('clients') or []
 
 
 class Snapshot:

--- a/boincui/server/main.py
+++ b/boincui/server/main.py
@@ -36,9 +36,14 @@ if args.options:
         logging.warning(f'No configuration file at {args.options}, starting unconfigured')
     except json.JSONDecodeError as error:
         logging.error(f'Ignoring unreadable configuration file {args.options}: {error}')
-# The password is never logged, at any level: this add-on holds a copy of the one that controls the
-# BOINC client, and DEBUG logs are what users paste into issues.
-logging.debug(f'Reading BOINC client at {options.get("boinc_host")}:{options.get("boinc_port")}')
+# Worked out once and shared, because the activity buttons address a machine by its position in this
+# very list.
+clients = clients_from(options)
+# Addresses only. The password is never logged, at any level: this add-on holds a copy of the one
+# that controls the BOINC client, and DEBUG logs are what users paste into issues.
+logging.debug('Watching ' + (', '.join(
+    f'{client.get("host")}:{client.get("port") or "default"}' for client in clients
+) or 'no machines'))
 
 stop_requested = threading.Event()
 
@@ -56,9 +61,6 @@ if args.exit_immediately:
 else:
     snapshot = Snapshot()
     app = create_app(snapshot)
-    # Worked out once and shared: calling this twice would log the deprecation warning twice, and
-    # the activity buttons address a machine by its position in this very list.
-    clients = clients_from(options)
     refresher = Refresher(snapshot, clients, stop_requested)
     app.config['CLIENTS'] = clients
     # Lets the "refresh now" button poll on demand instead of waiting for the next cycle.

--- a/boincui/server/templates/index.html
+++ b/boincui/server/templates/index.html
@@ -90,8 +90,8 @@
 </head>
 <body>
 <h1>BOINC UI</h1>
-<p class="muted">Experimental. Shows what your BOINC clients are doing, and lets you start and stop
-their computing.</p>
+<p class="muted">Shows what your BOINC clients are doing, and lets you start and stop their
+computing.</p>
 
 {% if machines is none %}
 <div class="card">

--- a/boincui/server/test/test_app.py
+++ b/boincui/server/test/test_app.py
@@ -199,22 +199,13 @@ class TestClientsFrom(unittest.TestCase):
 
         self.assertEqual([{'host': 'a', 'password': 'x'}], clients)
 
-    def test_should_accept_the_old_single_client_options(self):
-        # Supervisor silently drops options missing from the schema, so removing these outright
-        # would wipe an existing configuration. It still has to say so in the log.
-        with self.assertLogs(level='WARNING') as logged:
-            clients = clients_from({'boinc_host': 'pc', 'boinc_port': 31417, 'gui_rpc_password': 'x'})
-
-        self.assertEqual([{'name': 'pc', 'host': 'pc', 'port': 31417, 'password': 'x'}], clients)
-        self.assertIn('will stop working', ''.join(logged.output))
-
-    def test_should_prefer_the_list_over_the_old_options(self):
-        clients = clients_from({
-            'clients': [{'host': 'new', 'password': 'x'}],
-            'boinc_host': 'old', 'gui_rpc_password': 'y',
-        })
-
-        self.assertEqual('new', clients[0]['host'])
+    def test_should_ignore_the_single_client_options_removed_in_1_0(self):
+        # They are gone from the schema, so Supervisor can no longer deliver them. Reading them
+        # again would quietly resurrect a configuration path that is no longer documented or tested.
+        self.assertEqual(
+            [],
+            clients_from({'boinc_host': 'pc', 'boinc_port': 31417, 'gui_rpc_password': 'x'}),
+        )
 
     def test_should_return_nothing_when_unconfigured(self):
         self.assertEqual([], clients_from({}))

--- a/boincui/translations/en.yaml
+++ b/boincui/translations/en.yaml
@@ -14,12 +14,3 @@ configuration:
   password:
     name: Password
     description: "Must match the GUI RPC password set on that machine. Without it the client refuses the connection"
-  boinc_host:
-    name: BOINC client address (old setting)
-    description: "Replaced by the client list above. Move your settings there; this will stop working in a future version"
-  boinc_port:
-    name: BOINC client port (old setting)
-    description: "Replaced by the client list above. Move your settings there; this will stop working in a future version"
-  gui_rpc_password:
-    name: BOINC client password (old setting)
-    description: "Replaced by the client list above. Move your settings there; this will stop working in a future version"

--- a/boincui/translations/es.yaml
+++ b/boincui/translations/es.yaml
@@ -14,12 +14,3 @@ configuration:
   password:
     name: Contraseña
     description: "Tiene que coincidir con la contraseña de GUI RPC de esa máquina. Sin ella el cliente rechaza la conexión"
-  boinc_host:
-    name: Dirección del cliente BOINC (ajuste antiguo)
-    description: "Sustituido por la lista de clientes de arriba. Mueve ahí tus ajustes; esto dejará de funcionar en una versión futura"
-  boinc_port:
-    name: Puerto del cliente BOINC (ajuste antiguo)
-    description: "Sustituido por la lista de clientes de arriba. Mueve ahí tus ajustes; esto dejará de funcionar en una versión futura"
-  gui_rpc_password:
-    name: Contraseña del cliente BOINC (ajuste antiguo)
-    description: "Sustituido por la lista de clientes de arriba. Mueve ahí tus ajustes; esto dejará de funcionar en una versión futura"


### PR DESCRIPTION
BOINC UI reads every configured BOINC machine and can start and stop each one's computing. That is enough to stop calling it experimental, which is all this release says — **there is no new functionality in it**.

## Why dropping `stage: experimental` is the whole point

**Home Assistant stops flagging the app as experimental.** `stage` is now unset, like the other two add-ons, which Supervisor reads as `stable` (`AppStage`, `supervisor/const.py:490`). Confirmed on a running Supervisor: `version: 1.0.0 | stage: stable`.

**The Bluesky announcement stops being skipped.** The gate in `release.yaml` is literally `if: steps.version.outputs.stage != 'experimental'`, so this is the first `boincui` release that gets announced. Confirmed as intended.

## ⚠️ Breaking: the single-client options are gone

`boinc_host`, `boinc_port` and `gui_rpc_password` are removed from the schema, the translations and the docs, and `clients_from` no longer reads them.

`TODO.md` had this down for 0.6.0. It moved **forward** rather than back, for a reason worth stating: once an add-on is stable its option schema is a commitment, and removing an option is a breaking change that would call for a 2.0. **1.0 was the last cheap moment.**

A test asserts the old keys stay unread, so the path cannot come back by accident.

## Migration, which is where all the risk in this release lives

Both cases exercised against a real Supervisor:

**Still on the old options** → the add-on **starts**. Supervisor turns out to keep the removed keys in its own store while stripping them from what the process receives, so `/data/options.json` arrives as `{"clients": []}` and the page shows *"No BOINC client is configured"* with instructions — not a validation failure, not a blank page, and nothing destroyed.

**Already on the `clients` list** → untouched. Both machines render, the activity control shows `auto`, the unreachable one reports itself, exactly as in 0.5.0.

The `CHANGELOG.md` entry leads with the removal, since that tab is the only thing anyone reads before updating.

## Three texts that were no longer true

- **`README.md`** described the app as *"experimental and read-only … but not change it"*. That stopped being true in 0.5.0 and I missed it in that PR.
- **`DOCS.md`** still called it experimental and still carried an *Upgrading from an earlier version* section about options that no longer exist.
- **The page itself** opened with *"Experimental."*

## Also in here

- All three `icon.png` are **256x256**, so the `TODO.md` item claiming a 1x1 violation at 256x245 was stale. Closed with the measurement.
- **`docker stop hassio_supervisor` takes the devcontainer's own Docker daemon down with it** — `supervisor_run` runs under `set -e`, the container stays `Up` while every inner `docker` call fails, and `docker restart` does not recover it; `supervisor.sh up` does. It cost time today and is now a documented trap in the skill.

## Verification

62 tests green, including inside the image on Python 3.13.5; `hadolint`, `yamllint` and `mkdocs --strict` clean; smoke test passes; and the two migration paths above driven against a real Supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015y5PXHw6syYDUTUL7wRdSP