### PR TITLE
feat(boinc): choose the projects to compute for from the app configuration

### DIFF
--- a/.claude/skills/run-boinc-addons/SKILL.md
+++ b/.claude/skills/run-boinc-addons/SKILL.md
@@ -195,10 +195,22 @@ Gotchas.
      stack is gone. `docker restart ha-addons-dev` alone does **not** bring it back —
      re-run `supervisor.sh up`, which is idempotent and recovers in about a minute
      since the images are already in the volume. Use `restart`, never `stop`.
+  7. **A devcontainer that is merely stopped needs two fixes before it boots again**,
+     both now handled by `up`. `docker inspect` succeeds for a stopped container, so
+     testing existence is not enough — `up` used to skip straight to `docker exec` and
+     die with `container ... is not running`. And after an unclean stop, `supervisor_run`
+     reads a stale `/var/run/docker.pid`, decides `dockerd` is already up, cannot connect
+     and gives up, leaving only `Cannot connect to the Docker daemon` followed by
+     `Sending SIGTERM to docker daemon <stale pid>` in `/tmp/supervisor.log`. `up` now
+     starts the container and clears that pidfile before launching `supervisor_run`.
 - **An installed add-on's metadata is a snapshot.** Supervisor stores the parsed
   `config.yaml`/`translations` in `/mnt/supervisor/apps.json` at install time, so
   `ha apps info` keeps serving the old values after you edit those files — even
-  across a Supervisor restart. Re-run `install` to re-read them.
+  across a Supervisor restart. Re-run `install` to re-read them: it uninstalls the
+  previous copy first, since Supervisor otherwise refuses with `App ... is already
+  installed`. **That discards the app's `/data`**, which is what you want when
+  testing a schema and not what you want when testing an upgrade — for an upgrade,
+  bump the version and run `ha apps update local_<addon>` by hand.
 - **`ha apps logs local_boinctui` is legitimately empty** until something connects
   through ingress: `ttyd` writes nothing on startup. `local_boinc` logs immediately.
 - **Operator unit tests silently under-report** if `dict2xml` isn't installed:

--- a/.claude/skills/run-boinc-addons/supervisor.sh
+++ b/.claude/skills/run-boinc-addons/supervisor.sh
@@ -46,6 +46,32 @@ supervisor_running() {
     indocker 'docker inspect -f "{{.State.Status}}" hassio_supervisor 2>/dev/null' 2>/dev/null | grep -q running
 }
 
+container_running() {
+    [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" = "true" ]
+}
+
+# supervisor_run starts the devcontainer's own dockerd, but on a container that was stopped
+# uncleanly it finds a stale /var/run/docker.pid, concludes the daemon is already up, fails to
+# connect to it and gives up -- leaving the whole hassio stack down with nothing but
+# `Cannot connect to the Docker daemon` in /tmp/supervisor.log. Clearing the pidfile and starting
+# dockerd ourselves first is what makes a restart behave like a first boot.
+ensure_docker() {
+    indocker 'docker info' >/dev/null 2>&1 && return
+
+    echo "==> starting the devcontainer's Docker daemon"
+    docker exec -d "$CONTAINER" bash -lc 'rm -f /var/run/docker.pid && dockerd > /tmp/dockerd.log 2>&1'
+
+    local waited=0
+    until indocker 'docker info' >/dev/null 2>&1; do
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge 60 ]; then
+            echo "error: dockerd did not start inside $CONTAINER; see /tmp/dockerd.log there" >&2
+            exit 1
+        fi
+    done
+}
+
 cmd_up() {
     if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
         echo "==> starting devcontainer $CONTAINER"
@@ -57,7 +83,14 @@ cmd_up() {
             -p 7123:8123 -p 7357:4357 -p 21416:31416 \
             "$IMAGE" sleep infinity >/dev/null
         indocker 'bash /usr/bin/supervisor_bootstrap'
+    elif ! container_running; then
+        # `docker inspect` succeeds for a stopped container too, so testing existence alone left
+        # every command below failing with `container ... is not running`.
+        echo "==> restarting existing devcontainer $CONTAINER"
+        docker start "$CONTAINER" >/dev/null
     fi
+
+    ensure_docker
 
     if supervisor_running; then
         echo "==> Supervisor already running"
@@ -90,6 +123,17 @@ cmd_install() {
         echo "error: Supervisor is not running, run '$(basename "$0") up' first" >&2
         exit 1
     }
+
+    # Supervisor refuses to install over an existing app with `App ... is already installed`, so
+    # every iteration used to need a manual uninstall first. Reinstalling is also the only way to
+    # re-read config.yaml and translations, which Supervisor snapshots into apps.json at install
+    # time -- editing them and restarting keeps serving the old values.
+    # Note this discards the app's /data, which is the point when testing a schema and a nuisance
+    # when testing an upgrade: for that, edit the version and use `ha apps update` by hand instead.
+    if ha "apps info local_$addon" >/dev/null 2>&1; then
+        echo "==> uninstalling the previously installed local_$addon"
+        ha "apps uninstall local_$addon" >/dev/null
+    fi
 
     echo "==> staging $addon into the local store"
     # A copy, not a bind mount: Supervisor keeps submounts from its own start in its mount

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Standing backlog for this repo: known gaps, platform conformance items, and feat
 review. Consult it before starting work — what you are about to investigate may already be written
 up here with file:line references — and update it as items are resolved or discarded.
 
-Last reviewed 2026-08-11. Everything in **Resolved** below has shipped or been deliberately
+Last reviewed 2026-08-15. Everything in **Resolved** below has shipped or been deliberately
 discarded; it is kept in condensed form so the same ground is not re-covered, not as work to do.
 
 ---
@@ -272,31 +272,14 @@ of cost.
 
 ### `boinc` operator
 
-- [ ] **Declare projects to attach in the add-on options** (a `projects:` list). Attractive, but a
-  much bigger step than the existing scalar options, because it turns reconciliation into *set*
-  reconciliation with a destructive removal branch:
-  - **Detach is destructive**, unlike the account-manager detach the operator already does:
-    `boinccmd --project <url> detach` aborts in-progress tasks and deletes downloaded files. So
-    `actual − desired` must *not* map to detach. The BOINC-native soft equivalent is `nomorework`:
-    stop fetching, let current tasks drain. Default to draining; hard detach only on explicit opt-in.
-  - **Ownership needs persisted state**, because BOINC has no labels/annotations on a project.
-    Without a marker, a project the user attached from `boinctui` is indistinguishable from one the
-    operator attached and the user then removed from the options. Same `kubectl apply` trick already
-    used for preferences: keep a `managed_projects` file under `/data` and compute removals as
-    `previously-managed − desired`, never `actual − desired`.
-  - **Mutually exclusive with the account manager**, which owns the project list and re-asserts it
-    on every sync. Reject that combination at startup rather than letting it oscillate.
-  - **Project URLs need canonicalising before diffing** — reuse `boinc/operator/url.py`, which
-    exists for exactly this.
-  - **Credentials**: attach takes an account key, so `--lookup_account <url> <email> <password>`
-    first — a network call per project that can fail or rate-limit.
-  - **This is the first place a real retry loop earns its keep.** Projects go offline for days; a
-    one-shot attach at startup means "project was down at boot → silently never attached". Retry the
-    *additive* half with backoff, never police the removal half on a timer.
-  - **Partial failure becomes normal**: per-project error isolation plus an aggregated result, and
-    the outcome has to reach the exit code.
+None open. The `projects:` list shipped in 3.10.0 — see Resolved.
 
 ## Housekeeping
+
+- [ ] **`boinccmd.py:51` has a vestigial `while not current_account_manager_read:` loop** that always
+  runs exactly once, because its body either returns or sets the flag. Probably a retry loop that
+  lost its retry. Noticed while removing the `sleep(10)` next to it in 3.10.0 and deliberately left
+  alone to keep that change small.
 
 - [ ] `boinc/apparmor.txt.disable` is unmodified add-on template boilerplate (references
   `/etc/services.d`, `/etc/cont-init.d`, bashio, s6-overlay `/init`) — none of which this add-on
@@ -531,6 +514,65 @@ of cost.
   new code**: the `niu_` keys stayed in `MANAGED_PREFERENCES`, so a stale value the operator wrote
   itself falls into the removal branch that has existed since 3.8.1, while one set by the user from
   `boinctui` is untouched.
+
+## Shipped in `boinc` 3.10.0
+
+- [x] **`projects:` — declare the projects to attach in the add-on options.** New
+  `boinc/operator/projects.py` reconciling three sets on every start: `desired` (the option,
+  canonicalized through `url.py`), `actual` (`--get_project_status`), and `managed`
+  (`.managed_projects.json`, the `kubectl apply` pattern already used for preferences). The
+  ownership file has **two** lists, `attached` and `detaching`. Five of the seven constraints
+  written up here survived contact; the design notes below are what measurement changed, so the
+  same ground is not re-covered:
+  - **Credentials: an `account_key` per project, not email + password.** That removes
+    `--lookup_account` entirely, and with it two traps found in BOINC 8.2.15: it takes its exit
+    code from the *initial* RPC rather than the poll, so a failed lookup prints
+    `poll status: can't resolve hostname` and still **exits 0**; and its poll loop has no sleep and
+    no break when the poll RPC itself errors, i.e. an infinite busy loop upstream. Success is only
+    detectable as `account key: <auth>` on stdout.
+  - **Removal is `detach_when_done`, not `nomorework` and not a bare `detach`.** It drains first and
+    detaches after, so no completed work is destroyed. Its flag is **not** among the fields
+    `--get_project_status` prints, which is the whole reason the state file needs a second list: a
+    pending detach is invisible from outside, so a project removed and then re-added would otherwise
+    have a detach fire silently days later. Re-adding sends `dont_detach_when_done` **and**
+    `allowmorework`; BOINC's source pairs the two, but that pairing was the one thing not verified
+    live, so it is asserted explicitly instead of assumed.
+  - **The retry loop earns much less than expected.** `--project_attach` is a *local* RPC that
+    returns instantly and persists even against an unresolvable host — the client then retries the
+    project's own scheduler by itself, indefinitely. So "the project is down" was never the
+    operator's problem. What remains is a bounded backoff (30s → 30min) for a client that is not
+    answering yet, run from the loop that already watches the client rather than a thread.
+  - **No background thread, and the main loop stopped polling.** A thread only earns its place if
+    the attach can block on the network, and it cannot. The wait loop is now `boinc_process.wait()`:
+    in CPython 3.13, `wait()` with no timeout is a blocking `waitpid()`, while `wait(timeout=...)` is
+    an explicit busy loop sleeping up to 50 ms — *worse* than the `sleep(0.5)` it replaced. The
+    operator is now idle in the steady state instead of waking twice a second for the life of the
+    container.
+  - **Reconciliation runs at startup only.** Home Assistant cannot apply an options change without
+    restarting the app, so there is nothing new to read afterwards. A periodic check was rejected
+    for a second reason: combined with the re-attach behaviour below it would make BOINC Manager's
+    detach button useless for any listed project.
+  - **A project detached outside the options comes back on the next start**, deliberately and with
+    no special-cased log line — it is simply `desired − actual`. Consistent with the operator
+    re-asserting its own preference keys on every start. Documented in `DOCS.md`.
+  - **The account manager is refused, not merged**: `projects` plus any `account_manager_url` is a
+    startup failure, before the client is even launched. Separately, a project reported as
+    `attached via Account Manager: yes` is excluded from the diff entirely, which covers a manager
+    attached outside the options.
+  - **Verified end to end against a real client**, not only in unit tests: attach with URL
+    canonicalization, removal → `detach_when_done`, a project attached by hand left untouched, the
+    state file self-healing once the client lets a project go, re-add re-attaching, and the account
+    manager conflict exiting 1 without starting BOINC.
+
+- [x] **`sleep(10)` between detaching and attaching an account manager — deleted, not shortened.**
+  BOINC's `--acct_mgr detach` is `rpc.acct_mgr_rpc("", "", "")`, a single synchronous RPC
+  (`client/boinc_cmd.cpp`); only `attach` and `sync` poll, and they do it inside `boinccmd`. So the
+  wait was for something that had already happened. It also mattered because of what it exposed:
+  `time.sleep()` is *resumed* after a signal handler runs rather than cut short (PEP 475, measured —
+  handler at 0.31 s, `sleep(3)` still returning at 3.01 s), so a stop during that window ended in an
+  attach against a dead client and a **misleading `exit 1`**. `main.py` now re-checks for a stop
+  *after* `configure_boinc_projects` returns, not only before calling it — the same distinction
+  3.8.5 drew for a stop during initialization.
 
 ## Shipped as `boincui`, 0.1.0 → 1.0.0
 

--- a/TODO.md
+++ b/TODO.md
@@ -47,24 +47,6 @@ findings measured directly against the Supervisor in `.devcontainer`.
   on the running add-on reports `/config rw=false`), so the switch would not change access when it
   eventually happens.
 
-- [x] **Option types — closed 2026-08-15, both halves.** The first half was already **stale**:
-  `account_manager_url` has been `url?` since 3.9.1, not `str?` as this item claimed.
-  The second half is now measured against a running Supervisor rather than guessed. `remote_hosts`
-  keeps `- "str?"`, and changing it to `- "str"` would demonstrate nothing:
-  - The element **type is enforced either way** — `remote_hosts: [1234]` is rejected with
-    `expected str`.
-  - The `?` does **not** make elements nullable — `remote_hosts: [null]` is rejected, and with a
-    confusing message at that: `Missing required option 'remote_hosts'`, i.e. Supervisor reads a
-    null first element as the option being absent rather than as a bad element.
-  - The option itself is optional regardless: options posted with no `remote_hosts` key are
-    accepted.
-  Related and worth keeping in mind for any future list option: a list of dicts is the opposite —
-  posting options **without** `projects` is rejected with `Missing option 'projects' in root`, which
-  is exactly why `config.yaml` must carry `options: projects: []`. Verified that this does not break
-  existing installs: a real 3.9.1 install with five options and no `projects` key, updated in place
-  with `ha apps update`, came up `started` with every option preserved and `projects: []` filled in
-  from the schema default.
-
 - [ ] **`build.yaml` itself is deprecated.** Supervisor, on every store scan: `App local_boinc uses
   build.yaml which is deprecated. Move build parameters into the Dockerfile directly.` Both
   add-ons still ship one. This does **not** compose with simply deleting the file: Supervisor passes
@@ -90,6 +72,32 @@ findings measured directly against the Supervisor in `.devcontainer`.
   architectures by name (`amd64`, `aarch64`), so a new arch needs that `case` extended.
 
 ### Confirmed correct — checked, no action needed
+
+- **Option types are right as they stand, and the old item about them was half stale (2026-08-15).**
+  `account_manager_url` has been `url?` since 3.9.1, not the `str?` that item claimed. The other
+  half is now measured against a running Supervisor rather than guessed: `remote_hosts` keeps
+  `- "str?"`, because changing it to `- "str"` would demonstrate nothing. The element type is
+  enforced either way (`[1234]` → `expected str`); the `?` does not make elements nullable
+  (`[null]` is rejected, confusingly, as `Missing required option 'remote_hosts'` — Supervisor reads
+  a null first element as the option being absent); and the option is optional regardless, since
+  options posted with no `remote_hosts` key are accepted.
+  **A list of *dicts* behaves the opposite way**, which is worth knowing before adding another one:
+  options posted without `projects` are rejected with `Missing option 'projects' in root`, hence the
+  mandatory `options: projects: []` in `config.yaml`. That does not break existing installs —
+  verified by updating a real 3.9.1 install with five options and no `projects` key in place with
+  `ha apps update`: it came up `started`, every option preserved, `projects: []` filled in from the
+  schema default.
+- **The Dockerfile labels already agree; that item was stale too (2026-08-15).** It described
+  `image.vendor` disagreeing between add-ons, three spellings of the licence, and `image.url`
+  pointing at the repo in one place and the docs site in another. None of it is true now: the three
+  `LABEL` blocks are identical apart from the add-on's own name, every `licenses` is the SPDX
+  `Apache-2.0` in both the Dockerfiles and the `build.yaml` files, `vendor` is "Hector Espert"
+  everywhere and `url` is the docs site everywhere. The only place those old spellings survived was
+  the TODO entry describing them.
+  One real difference is left and it belongs to the `build.yaml` item above, not here: the
+  `build.yaml` labels use their own title and description ("Boinc add-on") and hardcode `source`,
+  where the Dockerfile uses `${BUILD_REPOSITORY}`. Worth settling *if* `build.yaml` survives; there
+  is no point tidying a file slated for removal.
 
 - **Every permission this repo requests is now explained to the user.** `host_pid`/`host_uts` by the
   Protection Mode warning, and `video`/`docker_api` by the *What else this app asks for* section
@@ -168,16 +176,6 @@ findings measured directly against the Supervisor in `.devcontainer`.
   docker-in-docker needs `--privileged`, a TTY, a health-check override and a ~2GB pull, so it is
   slow and fragile. Realistic middle ground: keep it a documented manual step before releasing a
   change to `config.yaml`/`build.yaml`/`translations/`, and revisit a nightly (not per-PR) job.
-
-- [x] **`supervisor.sh install <addon>` fails with `App … is already installed`** — fixed
-  2026-08-15: it uninstalls first, which is also the only way to make Supervisor re-read
-  `config.yaml` and `translations/`, since it snapshots them into `apps.json` at install time. Note
-  the uninstall discards the app's `/data`, so an *upgrade* still has to be tested by bumping the
-  version and running `ha apps update` by hand.
-  Fixed alongside it, found the same day: `up` treated an existing-but-stopped container as running
-  (`docker inspect` succeeds for a stopped one) and then died on `docker exec`; and after an unclean
-  stop `supervisor_run` gives up on a stale `/var/run/docker.pid`, so `up` now clears it and starts
-  `dockerd` itself. Between them, the documented recovery for gotcha 6 actually works unattended.
 
 ## Config schema — breaking redesign, for a future major
 
@@ -325,20 +323,14 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
 
 ## Housekeeping
 
-- [x] **`boinccmd.py`'s vestigial `while not current_account_manager_read:` loop** — removed in
-  3.10.0. It always ran exactly once, because its body either returned or set the flag; probably a
-  retry loop that lost its retry.
 
 - [ ] `boinc/apparmor.txt.disable` is unmodified add-on template boilerplate (references
   `/etc/services.d`, `/etc/cont-init.d`, bashio, s6-overlay `/init`) — none of which this add-on
   uses; its entrypoint is a plain `python3 /opt/operator/main.py`. Inert today (`apparmor: false`),
   but it would need a full rewrite, not just re-enabling. Either rewrite it to match the real
   process tree or delete it so it does not mislead a future contributor.
-- [ ] The Dockerfile labels disagree between add-ons without reason: `image.vendor` is
-  "Hector Espert" in one and "Home Assistant Boinc Add-ons" in the other; `image.licenses` is
-  "Apache 2.0", "Apache2" and "Apache License 2.0" depending on where you look, counting the
-  `build.yaml` files; and `image.url` points at the repo in one and the docs site in the other.
-  Pick one set — SPDX `Apache-2.0`, vendor "Hector Espert", the docs site — and apply it to both.
+- The Dockerfile labels item was **stale and is closed** — see *Confirmed correct* under
+  Conformance. They already agree across all three add-ons.
 
 ---
 
@@ -643,6 +635,10 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     that note describes a failure minutes into a run, while this one exits within a second of start,
     so the two are not necessarily in conflict — but a fast hard failure is visibly an error.
 
+- [x] **`boinccmd.py`'s vestigial `while not current_account_manager_read:` loop — removed.** It
+  always ran exactly once, since its body either returned or set the flag; probably a retry loop
+  that lost its retry. Found next to the `sleep(10)` below.
+
 - [x] **`sleep(10)` between detaching and attaching an account manager — deleted, not shortened.**
   BOINC's `--acct_mgr detach` is `rpc.acct_mgr_rpc("", "", "")`, a single synchronous RPC
   (`client/boinc_cmd.cpp`); only `attach` and `sync` poll, and they do it inside `boinccmd`. So the
@@ -652,6 +648,24 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
   attach against a dead client and a **misleading `exit 1`**. `main.py` now re-checks for a stop
   *after* `configure_boinc_projects` returns, not only before calling it — the same distinction
   3.8.5 drew for a stop during initialization.
+
+## Shipped alongside `boinc` 3.10.0 — repo tooling, not an add-on
+
+- [x] **`supervisor.sh` could not be run twice (2026-08-15).** Three failures, all hit while
+  validating the `projects` schema against a real Supervisor:
+  - `install <addon>` refused with `App … is already installed`, so every iteration needed a manual
+    uninstall. It uninstalls first now — which is also the only way to make Supervisor re-read
+    `config.yaml` and `translations/`, since it snapshots them into `apps.json` at install time.
+    **That discards the app's `/data`**, so an *upgrade* still has to be tested by bumping the
+    version and running `ha apps update` by hand, which is how the 3.9.1 → 3.10.0 check above ran.
+  - `up` treated an existing-but-stopped container as running, because `docker inspect` succeeds for
+    a stopped one, and then died on the first `docker exec`.
+  - After an unclean stop, `supervisor_run` reads a stale `/var/run/docker.pid`, concludes dockerd
+    is up, fails to connect and gives up — leaving only `Cannot connect to the Docker daemon` and a
+    `SIGTERM` aimed at a pid from the previous boot. `up` now clears that pidfile and starts dockerd
+    itself.
+
+  Between them, the recovery that gotcha 6 in `SKILL.md` documents actually works unattended now.
 
 ## Shipped as `boincui`, 0.1.0 → 1.0.0
 

--- a/TODO.md
+++ b/TODO.md
@@ -563,6 +563,15 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     canonicalization, removal → `detach_when_done`, a project attached by hand left untouched, the
     state file self-healing once the client lets a project go, re-add re-attaching, and the account
     manager conflict exiting 1 without starting BOINC.
+  - **And against a real Supervisor** (`supervisor.sh`, 2026-08-15), which is the half CI cannot
+    see. Supervisor parses the option as `type: schema`, `multiple: true`, with `url` carrying
+    `format: url` and `account_key` `format: password`; both translations render; the
+    `options: projects: []` default lets a fresh install validate; and **the schema rejects at
+    tier 1**, before the container starts, with the message shown in the UI — `expected a URL` for a
+    malformed address and `Missing option 'account_key' in projects` for a half-filled entry. The
+    runtime conflict then reports **`state: error`**, not the `stopped` the 3.8.4 note predicted;
+    that note describes a failure minutes into a run, while this one exits within a second of start,
+    so the two are not necessarily in conflict — but a fast hard failure is visibly an error.
 
 - [x] **`sleep(10)` between detaching and attaching an account manager — deleted, not shortened.**
   BOINC's `--acct_mgr detach` is `rpc.acct_mgr_rpc("", "", "")`, a single synchronous RPC

--- a/TODO.md
+++ b/TODO.md
@@ -126,9 +126,15 @@ findings measured directly against the Supervisor in `.devcontainer`.
   slow and fragile. Realistic middle ground: keep it a documented manual step before releasing a
   change to `config.yaml`/`build.yaml`/`translations/`, and revisit a nightly (not per-PR) job.
 
-- [ ] **`supervisor.sh install <addon>` fails with `App … is already installed`** instead of
-  reinstalling, so every iteration needs a manual uninstall first. Small quality-of-life fix in the
-  driver, noticed while verifying the changes above.
+- [x] **`supervisor.sh install <addon>` fails with `App … is already installed`** — fixed
+  2026-08-15: it uninstalls first, which is also the only way to make Supervisor re-read
+  `config.yaml` and `translations/`, since it snapshots them into `apps.json` at install time. Note
+  the uninstall discards the app's `/data`, so an *upgrade* still has to be tested by bumping the
+  version and running `ha apps update` by hand.
+  Fixed alongside it, found the same day: `up` treated an existing-but-stopped container as running
+  (`docker inspect` succeeds for a stopped one) and then died on `docker exec`; and after an unclean
+  stop `supervisor_run` gives up on a stale `/var/run/docker.pid`, so `up` now clears it and starts
+  `dockerd` itself. Between them, the documented recovery for gotcha 6 actually works unattended.
 
 ## Config schema — breaking redesign, for a future major
 

--- a/TODO.md
+++ b/TODO.md
@@ -543,17 +543,22 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     have a detach fire silently days later. Re-adding sends `dont_detach_when_done` **and**
     `allowmorework`; BOINC's source pairs the two, but that pairing was the one thing not verified
     live, so it is asserted explicitly instead of assumed.
-  - **The retry loop earns much less than expected.** `--project_attach` is a *local* RPC that
-    returns instantly and persists even against an unresolvable host — the client then retries the
-    project's own scheduler by itself, indefinitely. So "the project is down" was never the
-    operator's problem. What remains is a bounded backoff (30s → 30min) for a client that is not
-    answering yet, run from the loop that already watches the client rather than a thread.
-  - **No background thread, and the main loop stopped polling.** A thread only earns its place if
-    the attach can block on the network, and it cannot. The wait loop is now `boinc_process.wait()`:
-    in CPython 3.13, `wait()` with no timeout is a blocking `waitpid()`, while `wait(timeout=...)` is
-    an explicit busy loop sleeping up to 50 ms — *worse* than the `sleep(0.5)` it replaced. The
-    operator is now idle in the steady state instead of waking twice a second for the life of the
-    container.
+  - **There is no retry at all, which took two goes to see.** `--project_attach` is a *local* RPC
+    that returns instantly and persists even against an unresolvable host — the client then retries
+    the project's own scheduler by itself, indefinitely. So "the project is down" was never the
+    operator's problem, which left only "the client is not answering yet" — and *that* window is
+    already closed by the initialization loop, since `configure_projects` runs only after
+    `boinccmd --get_state` has succeeded. A bounded backoff was written first and then deleted: it
+    guarded a case that cannot arise. A failed attach is now a warning naming the projects, retried
+    when the app restarts, which is when an options change takes effect anyway.
+  - **No background thread either, and nothing polls after startup.** A thread only earns its place
+    if the attach can block on the network, and it cannot. The wait loop is now a bare
+    `boinc_process.wait()`: in CPython 3.13, `wait()` with no timeout is a blocking `waitpid()`,
+    while `wait(timeout=...)` is an explicit busy loop sleeping up to 50 ms — *worse* than the
+    `sleep(0.5)` it replaced, and the trap waiting for anyone who reintroduces a periodic wake-up
+    here. Measured: the operator sits at `Threads: 1`, `State: S (sleeping)`. The one remaining
+    `sleep` is the initialization loop, which is inherent — it polls another process's readiness,
+    and there is no blocking primitive for that.
   - **Reconciliation runs at startup only.** Home Assistant cannot apply an options change without
     restarting the app, so there is nothing new to read afterwards. A periodic check was rejected
     for a second reason: combined with the re-attach behaviour below it would make BOINC Manager's

--- a/TODO.md
+++ b/TODO.md
@@ -557,8 +557,25 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     while `wait(timeout=...)` is an explicit busy loop sleeping up to 50 ms — *worse* than the
     `sleep(0.5)` it replaced, and the trap waiting for anyone who reintroduces a periodic wake-up
     here. Measured: the operator sits at `Threads: 1`, `State: S (sleeping)`. The one remaining
-    `sleep` is the initialization loop, which is inherent — it polls another process's readiness,
-    and there is no blocking primitive for that.
+    `sleep` is the initialization loop, which stays — see below.
+  - **The initialization loop is now bounded, which was the real defect in it.** It had no deadline:
+    a client that starts but never answers RPCs left the operator spawning `boinccmd` twice a second
+    *forever* while Home Assistant reported the app as started — more polling than the retry loop
+    above ever did. Now it gives up after `--initialization-timeout` (300 s by default, generous
+    because taking a while normally means a slow host reading a large `client_state.xml`, and
+    stopping an app that was merely slow is the worse mistake), stops the client and exits 1 with a
+    message about the client rather than about the configuration. The probe also moved *before* the
+    first sleep, so a normal start no longer pays the interval for nothing.
+  - **Removing that last `sleep` with inotify was evaluated and rejected on price, not on
+    impossibility** — which corrects an earlier claim here that no blocking primitive existed. One
+    does: BOINC creates a Unix domain socket (`GUI_RPC_FILE`) and `bind()`s + `listen()`s on it
+    *before* setting up the TCP socket (`client/gui_rpc_server.cpp`), so there is a filesystem event
+    at the exact moment it starts accepting RPCs. What makes it a bad trade: the watch has to be
+    armed *before* `Popen` or the file can appear in the gap and block forever; BOINC `unlink()`s a
+    stale socket before binding, so a leftover from the previous start would fool a plain existence
+    check; a deadline and a confirming `--get_state` would still be needed; and all of that plus a
+    new Dockerfile dependency (`python3-watchdog`, or ~40 lines of `ctypes`) buys about three fewer
+    `boinccmd` spawns, once per container start.
   - **Reconciliation runs at startup only.** Home Assistant cannot apply an options change without
     restarting the app, so there is nothing new to read afterwards. A periodic check was rejected
     for a second reason: combined with the re-attach behaviour below it would make BOINC Manager's

--- a/TODO.md
+++ b/TODO.md
@@ -18,12 +18,20 @@ Resolved.
 
 ## Security / permissions
 
-- [ ] **`apparmor: false` on both add-ons, against an explicit documented recommendation.** These
-  add-ons disable AppArmor *and* request `host_pid`, `host_uts`, `docker_api` and `video`, so they
-  sit at the low end of the platform's 1–6 rating by construction. Ties to the dead
+- [ ] **`apparmor: false` on all three add-ons, against an explicit documented recommendation.**
+  These add-ons disable AppArmor *and* request `host_pid`, `host_uts`, `docker_api` and `video`, so
+  they sit at the low end of the platform's 1–6 rating by construction. Ties to the dead
   `boinc/apparmor.txt.disable` under Housekeeping: writing a real profile matching the actual
   process tree fixes both at once. Realistically a large task, not a quick win — but it should be a
   recorded decision rather than an unexamined default.
+
+  **What a profile can and cannot buy here, since it is not the usual case.** BOINC's whole purpose
+  is to download third-party binaries from projects and execute them out of `slots/`, so a profile
+  cannot meaningfully restrict *what runs* — it has to permit executing arbitrary downloaded code,
+  or the add-on does nothing. What it can still do is bound the *blast radius* of that code: keep it
+  out of `/config`, off the host paths `host_pid` exposes, and away from the Docker socket
+  `docker_api` grants. That is worth having, but it is a different claim from the one "AppArmor
+  enabled" usually implies, and the item should be judged on it rather than on the rating.
 
 ## Conformance with the official HA apps docs
 
@@ -323,12 +331,19 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
 
 ## Housekeeping
 
-
 - [ ] `boinc/apparmor.txt.disable` is unmodified add-on template boilerplate (references
   `/etc/services.d`, `/etc/cont-init.d`, bashio, s6-overlay `/init`) — none of which this add-on
-  uses; its entrypoint is a plain `python3 /opt/operator/main.py`. Inert today (`apparmor: false`),
-  but it would need a full rewrite, not just re-enabling. Either rewrite it to match the real
-  process tree or delete it so it does not mislead a future contributor.
+  uses; its entrypoint is a plain `python3 /opt/operator/main.py`. It still carries the template's
+  `my_program` placeholders and its commented-out "here is how to build the list" instructions, so
+  nobody ever adapted it. **Doubly inert**: `apparmor: false`, *and* Supervisor looks for
+  `apparmor.txt`, so the `.disable` suffix means it was never read either way. Only `boinc` has one;
+  `boinctui` and `boincui` declare `apparmor: false` with no file at all, so deleting it would make
+  the three consistent.
+  Either rewrite it to match the real process tree or delete it so it does not mislead a future
+  contributor. **If deleting: `CLAUDE.md` cites this exact path** as the example of why
+  `monitored_files` is a regex that can over-match (`app` would also match
+  `boinc/apparmor.txt.disable`), so that example needs a different filename or the note needs
+  rewording.
 - The Dockerfile labels item was **stale and is closed** — see *Confirmed correct* under
   Conformance. They already agree across all three add-ons.
 

--- a/TODO.md
+++ b/TODO.md
@@ -126,6 +126,38 @@ findings measured directly against the Supervisor in `.devcontainer`.
 
 ## Test coverage
 
+- [ ] **No project has ever been attached to a *real* BOINC project.** Everything verifying the
+  `projects` option in 3.10.0 — unit tests, the end-to-end lifecycle, the Supervisor run — used
+  `http://example.invalid/...` with invented account keys. That proves the operator issues the right
+  calls and that the client persists them; it proves nothing about a real project **accepting** the
+  key and sending work. Two things ride on it:
+  1. **Whether an account key in this option actually authenticates.** A rejected key still leaves
+     the project attached, so the failure is quiet: the client logs `Invalid or missing account key`
+     and the app looks fine. Nothing in the operator notices.
+  2. **`detach_when_done` draining real work**, which is the promise `DOCS.md` makes to the user —
+     *"finish the work it has already downloaded and then leave"*. Our test projects had zero tasks,
+     so that behaviour is asserted from BOINC's semantics, never measured.
+
+  **Procedure, for whoever picks it up.** Work in a gitignored scratch directory; the account key is
+  a secret and must not reach the repo or a transcript.
+  1. Register on a project with a steady Linux x86_64 work supply — Einstein@Home. World Community
+     Grid has had work droughts, which would waste the run.
+  2. Copy the *account key* from the project's own account page (look for "account keys"). The
+     alternative, `boinccmd --lookup_account`, is a GUI RPC so it needs a running client, and it
+     wants the project password as well.
+  3. Start the built image with that `options.json` and real network access.
+  4. **The check that matters**: `--get_project_status` must show a real `name:` and `user_name:`.
+     Those come from the scheduler's reply, so they stay empty when the key was rejected — which is
+     exactly the distinction `example.invalid` cannot make.
+  5. `--get_task_summary` should show work arriving.
+  6. Remove the project from the options and restart: expect `don't request more work: yes`, the
+     project **still attached**, and its tasks intact. That is the drain promise, on real work.
+  7. Re-add and restart: expect `don't request more work: no`.
+  8. Free extra: run at DEBUG and confirm `redact.py` masks a genuine key as `***`.
+
+  A full drain takes hours or days, so step 6 verifies the mechanism, not the completion. Detach
+  properly afterwards so the project is not left with an orphan host record.
+
 - [ ] **Nothing exercises the Home Assistant surface in CI**, only the container. Everything under
   Conformance above is invisible to `docker build`/`docker run`: `config.yaml`/`build.yaml`
   validation, the option schema, translations, ingress, protection mode, watchdog. There is a local

--- a/TODO.md
+++ b/TODO.md
@@ -47,12 +47,23 @@ findings measured directly against the Supervisor in `.devcontainer`.
   on the running add-on reports `/config rw=false`), so the switch would not change access when it
   eventually happens.
 
-- [ ] **`account_manager_url` is typed `str?` when the schema language has a `url` type.**
-  `boinc/config.yaml:21`. The `url` type exists (`supervisor/apps/options.py:25`) and gives
-  validation in the Supervisor UI instead of a runtime error from `boinccmd --acct_mgr attach`.
-  Same category: `remote_hosts` entries are `- "str?"`, and `?` marks optional *fields*, not
-  optional element types, so on a list element it likely means nothing — verify against Supervisor
-  before changing it to `- "str"`.
+- [x] **Option types — closed 2026-08-15, both halves.** The first half was already **stale**:
+  `account_manager_url` has been `url?` since 3.9.1, not `str?` as this item claimed.
+  The second half is now measured against a running Supervisor rather than guessed. `remote_hosts`
+  keeps `- "str?"`, and changing it to `- "str"` would demonstrate nothing:
+  - The element **type is enforced either way** — `remote_hosts: [1234]` is rejected with
+    `expected str`.
+  - The `?` does **not** make elements nullable — `remote_hosts: [null]` is rejected, and with a
+    confusing message at that: `Missing required option 'remote_hosts'`, i.e. Supervisor reads a
+    null first element as the option being absent rather than as a bad element.
+  - The option itself is optional regardless: options posted with no `remote_hosts` key are
+    accepted.
+  Related and worth keeping in mind for any future list option: a list of dicts is the opposite —
+  posting options **without** `projects` is rejected with `Missing option 'projects' in root`, which
+  is exactly why `config.yaml` must carry `options: projects: []`. Verified that this does not break
+  existing installs: a real 3.9.1 install with five options and no `projects` key, updated in place
+  with `ha apps update`, came up `started` with every option preserved and `projects: []` filled in
+  from the schema default.
 
 - [ ] **`build.yaml` itself is deprecated.** Supervisor, on every store scan: `App local_boinc uses
   build.yaml which is deprecated. Move build parameters into the Dockerfile directly.` Both
@@ -282,10 +293,9 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
 
 ## Housekeeping
 
-- [ ] **`boinccmd.py:51` has a vestigial `while not current_account_manager_read:` loop** that always
-  runs exactly once, because its body either returns or sets the flag. Probably a retry loop that
-  lost its retry. Noticed while removing the `sleep(10)` next to it in 3.10.0 and deliberately left
-  alone to keep that change small.
+- [x] **`boinccmd.py`'s vestigial `while not current_account_manager_read:` loop** — removed in
+  3.10.0. It always ran exactly once, because its body either returned or set the flag; probably a
+  retry loop that lost its retry.
 
 - [ ] `boinc/apparmor.txt.disable` is unmodified add-on template boilerplate (references
   `/etc/services.d`, `/etc/cont-init.d`, bashio, s6-overlay `/init`) — none of which this add-on

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.10.0
+
+Added `projects`, to choose the science projects yourself instead of letting an account manager choose them. Each one needs its address and your account key for it, and it cannot be combined with the account manager options
+
+Removing a project from that list makes BOINC finish the work it already downloaded before leaving the project, so nothing you have computed is thrown away. Projects you attached yourself are never removed
+
+Stop reporting a failure when the app is stopped while it is changing account manager
+
 ## 3.9.1
 
 The Account Manager URL field now rejects an address that is not a valid URL as you type it, instead of failing later when the app starts

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -8,6 +8,8 @@ Removing a project from that list makes BOINC finish the work it already downloa
 
 Stop reporting a failure when the app is stopped while it is changing account manager
 
+Stop the app with an error, visible in the Log tab, when the BOINC client starts but never becomes reachable, instead of waiting for it forever
+
 ## 3.9.1
 
 The Account Manager URL field now rejects an address that is not a valid URL as you type it, instead of failing later when the app starts

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -35,6 +35,42 @@ account_manager_username: "youremail@email.com"
 account_manager_password: "yoursecretpassword"
 ```
 
+### Choosing projects yourself (Advanced)
+
+If you would rather pick the science projects yourself instead of letting an account manager choose,
+list them in the app configuration. Each one needs its address and your **account key** for it.
+
+To find your account key: sign in on the project's own website, open your account page, and look for
+the account key — most projects show it there, sometimes behind a link called *account keys*. It is
+not your project password.
+
+```yaml
+projects:
+  - url: "https://einsteinathome.org/"
+    account_key: "your account key for this project"
+  - url: "https://www.worldcommunitygrid.org/"
+    account_key: "your account key for that project"
+```
+
+**You cannot use this together with an account manager.** An account manager decides on its own
+which projects you compute for, so the two would keep undoing each other. Set one or the other — if
+both are filled in, the app will not start, and the **Log** tab says so.
+
+What the app does with this list:
+
+- **Adding a project** attaches it the next time the app starts.
+- **Removing a project** from the list tells BOINC to finish the work it has already downloaded and
+  then leave the project. Nothing you have already computed is thrown away, so it may stay listed in
+  boinctui for a while until its last tasks are done and reported.
+- **Projects you attached yourself** — from the boinctui app, a remote BOINC Manager, or an account
+  manager — are never removed by this list. It only manages the projects it attached.
+- **Changes only take effect when the app restarts**, which Home Assistant asks you to do after you
+  save the configuration.
+
+One consequence worth knowing: if you leave a project in this list but detach it yourself from
+boinctui or BOINC Manager, the app attaches it again the next time it starts, because the list still
+asks for it. Remove it from the list to remove it for good.
+
 ### Remote Control (Advanced)
 
 [Remote GUI RPC](https://boinc.berkeley.edu/wiki/Controlling_BOINC_remotely) can be enabled in the app configuration and used to manage the BOINC client remotely.
@@ -101,6 +137,19 @@ stays attached. Detach it the same way you attached it.
 
 **Set only one or two of the three and the app will not start.** Open the app's **Log** tab to see
 why.
+
+#### Project Options
+
+- **projects** (optional, list)
+  - The science projects to compute for, chosen by you instead of by an account manager
+  - Each entry needs a **url** (the project's address, for example `https://einsteinathome.org/`)
+    and an **account_key** (found on your account page on that project's website)
+  - Leave the list empty to not manage projects from here at all
+  - Cannot be combined with the account manager options above — set one or the other, or the app
+    will not start
+
+See [Choosing projects yourself](#choosing-projects-yourself-advanced) above for how to find an
+account key and what happens when you add or remove a project.
 
 #### Remote Control Options
 
@@ -171,6 +220,16 @@ time, is ignored — BOINC computes all the time — and a warning explaining wh
 account_manager_url: "https://scienceunited.org"
 account_manager_username: "youremail@example.com"
 account_manager_password: "your_password"
+```
+
+#### Choosing Projects Instead of an Account Manager
+
+```yaml
+projects:
+  - url: "https://einsteinathome.org/"
+    account_key: "your_account_key_for_einstein"
+  - url: "https://www.worldcommunitygrid.org/"
+    account_key: "your_account_key_for_wcg"
 ```
 
 #### Computing Only at Night (22:00 to 07:00)

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -56,6 +56,13 @@ projects:
 which projects you compute for, so the two would keep undoing each other. Set one or the other — if
 both are filled in, the app will not start, and the **Log** tab says so.
 
+**If the account key is wrong, nothing looks broken.** The project is added anyway, the app keeps
+running, and it simply never receives any work. The project's website is what turns you away, not
+this app, so the only sign is in the app's **Log** tab: look for the project's name next to
+*Invalid or missing account key*. If you see it, correct the key and restart the app. This is worth
+knowing because it is easy to copy the wrong value — the account key is a long string of letters and
+numbers, not your password and not your email.
+
 What the app does with this list:
 
 - **Adding a project** attaches it the next time the app starts.

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC
-version: "3.9.1"
+version: "3.10.0"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"
@@ -13,7 +13,16 @@ video: true
 host_pid: true
 host_uts: true
 docker_api: true
+# A list-of-dict option cannot be marked optional: Supervisor's check for missing options only
+# honours a trailing "?" on a string, and for a list it looks at the first element, which here is a
+# dict. Without this default an empty configuration fails validation, so every existing install
+# would stop starting after the update.
+options:
+  projects: []
 schema:
+  projects:
+    - url: "url"
+      account_key: "password"
   gui_rpc_password: "password?"
   remote_hosts:
     - "str?"

--- a/boinc/operator/boinccmd.py
+++ b/boinc/operator/boinccmd.py
@@ -44,21 +44,16 @@ def sync_account_manager(data_folder: str) -> bool:
 
 def configure_boinc_projects(data_folder: str, account_manager_url: str | None, account_manager_username: str | None, account_manager_password: str | None) -> bool:
 
-    current_account_manager_url = None
-    current_account_manager_read = False
+    result = subprocess.run(["boinccmd", "--acct_mgr", "info"], capture_output=True, text=True, cwd=data_folder)
+    if result.returncode != 0:
+        logging.error(f'Failed to get account manager information: {result.stderr}')
+        return False
 
-    while not current_account_manager_read:
-        result = subprocess.run(["boinccmd", "--acct_mgr", "info"], capture_output=True, text=True, cwd=data_folder)
-        if result.returncode != 0:
-            logging.error(f'Failed to get account manager information: {result.stderr}')
-            return False
+    logging.debug(f'{result.stdout}')
 
-        logging.debug(f'{result.stdout}')
-
-        match = re.search(r'URL: (\S+)', result.stdout)
-        current_account_manager_url = match.group(1) if match else None
-        logging.info(f'Current account manager {current_account_manager_url}')
-        current_account_manager_read = True
+    match = re.search(r'URL: (\S+)', result.stdout)
+    current_account_manager_url = match.group(1) if match else None
+    logging.info(f'Current account manager {current_account_manager_url}')
 
     if any([account_manager_url, account_manager_username, account_manager_password]) and not all([account_manager_url, account_manager_username, account_manager_password]):
         # Half an account manager has no safe reading: attaching is impossible, and carrying on

--- a/boinc/operator/boinccmd.py
+++ b/boinc/operator/boinccmd.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import subprocess
-from time import sleep
 
 from url import canonicalize_url
 
@@ -82,8 +81,10 @@ def configure_boinc_projects(data_folder: str, account_manager_url: str | None, 
             if not result:
                 return False
 
-            sleep(10)
-
+            # Nothing to wait for in between: detach is a single synchronous RPC
+            # (`rpc.acct_mgr_rpc("", "", "")` in client/boinc_cmd.cpp), so the client has already
+            # processed it by the time boinccmd returns. Only attach and sync poll, and they do it
+            # inside boinccmd itself.
             return attach_account_manager(data_folder, account_manager_url, account_manager_username, account_manager_password)
 
     elif current_account_manager_url is not None:

--- a/boinc/operator/main.py
+++ b/boinc/operator/main.py
@@ -91,12 +91,15 @@ signal.signal(signal.SIGTERM, signal_handler)
 # tests that need to signal this process and know the signal will actually be handled.
 logging.info(f'BOINC Add-on Operator started')
 
-# Polling is unavoidable here: this waits for another process to become ready, and there is no
-# blocking primitive for that -- a connect to a port with no listener is refused immediately rather
-# than blocking. It is bounded, though. Left unbounded, a client that starts but never answers
-# leaves the operator spawning boinccmd twice a second forever while Home Assistant reports the app
-# as started. The deadline is deliberately generous: taking a while normally means a slow host
-# reading a large client_state.xml, and stopping an app that was merely slow is the worse mistake.
+# Polling, because the cheap alternatives do not exist: a connect to a port with no listener is
+# refused immediately rather than blocking. A blocking primitive does exist -- BOINC binds a Unix
+# domain socket before the TCP one, so inotify would wake at exactly the right moment -- but it
+# costs a dependency and two race conditions to save three boinccmd spawns per start; the full
+# reasoning is in TODO.md so it is not re-derived here.
+# Bounded, though. Left unbounded, a client that starts but never answers leaves the operator
+# spawning boinccmd twice a second forever while Home Assistant reports the app as started. The
+# deadline is deliberately generous: taking a while normally means a slow host reading a large
+# client_state.xml, and stopping an app that was merely slow is the worse mistake.
 INITIALIZATION_POLL_INTERVAL = 0.5
 
 boinc_process_initialized = False

--- a/boinc/operator/main.py
+++ b/boinc/operator/main.py
@@ -5,7 +5,7 @@ import os
 import signal
 import subprocess
 import sys
-from time import sleep
+from time import monotonic, sleep
 
 from boinc import build_boinc_command
 from boinccmd import configure_boinc_projects, get_state
@@ -13,6 +13,7 @@ from cc_config import prepare_cc_config
 from folders import prepare_data_folders
 from global_prefs_override import link_global_prefs_override
 from gui_rpc_auth import prepare_gui_rpc_auth
+from projects import RETRY_INITIAL_DELAY, RETRY_MAX_DELAY, configure_projects, validate_projects
 from redact import redact_secrets
 from remote_hosts import prepare_remote_hosts
 
@@ -41,6 +42,12 @@ logging.info(f'Configuration loaded from {args.options.name}')
 
 options = json.load(args.options)
 logging.debug(f'Current configuration\n{json.dumps(redact_secrets(options), indent=2)}')
+
+# Checked before anything is started because it needs no client to answer it: a contradiction
+# between the options is the one kind of failure that is cheaper to report than to act on.
+if not validate_projects(options.get('projects'), options.get('account_manager_url')):
+    logging.error(f'BOINC Add-on Operator stopped: the configured projects cannot be applied')
+    sys.exit(1)
 
 data_folder = args.data
 logging.info(f'BOINC data folder {data_folder}')
@@ -92,16 +99,28 @@ while boinc_process.poll() is None and not boinc_process_initialized:
     else:
         logging.debug(f'Waiting for BOINC client to initialize')
 
+pending_projects = []
+
 # A stop requested during initialization (a signal, or the client dying on its own) already means
 # there is nothing left to configure: skipping this avoids running boinccmd against a client that
 # is no longer there to answer it, which would otherwise be misreported as a configuration failure.
 if not stopping_boinc_process and boinc_process.poll() is None:
     projects_configured = configure_boinc_projects(data_folder, options.get('account_manager_url'), options.get('account_manager_username'), options.get('account_manager_password'))
-    if not projects_configured:
+
+    # Asked again after the call and not only before it: attaching an account manager polls it over
+    # the network from inside boinccmd, so a stop arriving meanwhile leaves it talking to a client
+    # that is already gone. That is a stop, not a configuration mistake, and 3.8.5 drew the same
+    # line for a stop during initialization.
+    stopping = stopping_boinc_process or boinc_process.poll() is not None
+
+    if not projects_configured and not stopping:
         boinc_process.send_signal(signal.SIGTERM)
         boinc_process.wait()
         logging.error(f'BOINC Add-on Operator stopped: failed to configure BOINC projects')
         sys.exit(1)
+
+    if not stopping:
+        pending_projects = configure_projects(data_folder, options.get('projects'))
 
 if args.exit_immediately:
     logging.warning(f'Exiting immediately after BOINC client is started')
@@ -109,8 +128,23 @@ if args.exit_immediately:
     boinc_process.send_signal(signal.SIGTERM)
     boinc_process.wait()
 
-while boinc_process.poll() is None:
+# Reconciling the configured projects happens once, at startup: Home Assistant cannot apply an
+# options change without restarting the app, so there is nothing new to read afterwards. The only
+# reason left to wake up is an attach that failed, and only until it succeeds.
+retry_delay = RETRY_INITIAL_DELAY
+next_retry = monotonic() + retry_delay
+
+while pending_projects and boinc_process.poll() is None:
     sleep(0.5)
+    if monotonic() >= next_retry:
+        pending_projects = configure_projects(data_folder, options.get('projects'))
+        retry_delay = min(retry_delay * 2, RETRY_MAX_DELAY)
+        next_retry = monotonic() + retry_delay
+
+# With nothing left to retry, block on the client rather than polling it: wait() with no timeout is
+# a blocking waitpid(), while wait(timeout=...) is a busy loop sleeping up to 50ms a turn -- worse
+# than the sleep(0.5) this replaces. It returns immediately if the client is already gone.
+boinc_process.wait()
 
 logging.debug(f'BOINC client stopped with code {boinc_process.returncode}')
 

--- a/boinc/operator/main.py
+++ b/boinc/operator/main.py
@@ -5,7 +5,7 @@ import os
 import signal
 import subprocess
 import sys
-from time import sleep
+from time import monotonic, sleep
 
 from boinc import build_boinc_command
 from boinccmd import configure_boinc_projects, get_state
@@ -24,6 +24,7 @@ parser.add_argument('--data', type=str, required=True, help='BOINC data folder')
 parser.add_argument('--config', type=str, required=True, help='Add-on config folder')
 parser.add_argument("--log-level", default=logging.INFO, type=lambda x: getattr(logging, x))
 parser.add_argument("--exit-immediately", action='store_true', help="Exit immediately after BOINC client is started")
+parser.add_argument("--initialization-timeout", type=float, default=300, help="Seconds to wait for the BOINC client to answer before giving up")
 
 args = parser.parse_args()
 logging.basicConfig(level=args.log_level, format='%(asctime)s %(levelname)s %(message)s', datefmt="%Y-%m-%d %H:%M:%S")
@@ -90,14 +91,38 @@ signal.signal(signal.SIGTERM, signal_handler)
 # tests that need to signal this process and know the signal will actually be handled.
 logging.info(f'BOINC Add-on Operator started')
 
+# Polling is unavoidable here: this waits for another process to become ready, and there is no
+# blocking primitive for that -- a connect to a port with no listener is refused immediately rather
+# than blocking. It is bounded, though. Left unbounded, a client that starts but never answers
+# leaves the operator spawning boinccmd twice a second forever while Home Assistant reports the app
+# as started. The deadline is deliberately generous: taking a while normally means a slow host
+# reading a large client_state.xml, and stopping an app that was merely slow is the worse mistake.
+INITIALIZATION_POLL_INTERVAL = 0.5
+
 boinc_process_initialized = False
+initialization_deadline = monotonic() + args.initialization_timeout
+
 while boinc_process.poll() is None and not boinc_process_initialized:
-    sleep(0.5)
+    # Asked before the first sleep, not after it: the client is usually ready straight away, and
+    # sleeping first made every single start pay the interval for nothing.
     boinc_process_initialized = get_state(data_folder)
     if boinc_process_initialized:
         logging.debug(f'BOINC client initialized')
+    elif monotonic() >= initialization_deadline:
+        logging.error(f'BOINC client did not answer within {args.initialization_timeout} seconds')
+        break
     else:
         logging.debug(f'Waiting for BOINC client to initialize')
+        sleep(INITIALIZATION_POLL_INTERVAL)
+
+# Only when the client is still running: one that died on its own is not this failure, and the exit
+# code check at the end of this file already reports it. Without this branch the configuration below
+# would run against a client that cannot answer and blame the configuration for it.
+if not boinc_process_initialized and not stopping_boinc_process and boinc_process.poll() is None:
+    boinc_process.send_signal(signal.SIGTERM)
+    boinc_process.wait()
+    logging.error(f'BOINC Add-on Operator stopped: the BOINC client never became reachable')
+    sys.exit(1)
 
 # A stop requested during initialization (a signal, or the client dying on its own) already means
 # there is nothing left to configure: skipping this avoids running boinccmd against a client that

--- a/boinc/operator/main.py
+++ b/boinc/operator/main.py
@@ -5,7 +5,7 @@ import os
 import signal
 import subprocess
 import sys
-from time import monotonic, sleep
+from time import sleep
 
 from boinc import build_boinc_command
 from boinccmd import configure_boinc_projects, get_state
@@ -13,7 +13,7 @@ from cc_config import prepare_cc_config
 from folders import prepare_data_folders
 from global_prefs_override import link_global_prefs_override
 from gui_rpc_auth import prepare_gui_rpc_auth
-from projects import RETRY_INITIAL_DELAY, RETRY_MAX_DELAY, configure_projects, validate_projects
+from projects import configure_projects, validate_projects
 from redact import redact_secrets
 from remote_hosts import prepare_remote_hosts
 
@@ -99,8 +99,6 @@ while boinc_process.poll() is None and not boinc_process_initialized:
     else:
         logging.debug(f'Waiting for BOINC client to initialize')
 
-pending_projects = []
-
 # A stop requested during initialization (a signal, or the client dying on its own) already means
 # there is nothing left to configure: skipping this avoids running boinccmd against a client that
 # is no longer there to answer it, which would otherwise be misreported as a configuration failure.
@@ -120,7 +118,13 @@ if not stopping_boinc_process and boinc_process.poll() is None:
         sys.exit(1)
 
     if not stopping:
-        pending_projects = configure_projects(data_folder, options.get('projects'))
+        # Reconciling happens once, here: Home Assistant cannot apply an options change without
+        # restarting the app, so there is nothing new to read afterwards. Attaching is a local RPC
+        # against a client that has already answered --get_state, so a failure here is rare enough
+        # that saying so and moving on beats keeping the operator awake to try again.
+        unattached_projects = configure_projects(data_folder, options.get('projects'))
+        if unattached_projects:
+            logging.warning(f'These projects could not be attached and will be attempted again when the app restarts: {", ".join(unattached_projects)}')
 
 if args.exit_immediately:
     logging.warning(f'Exiting immediately after BOINC client is started')
@@ -128,22 +132,11 @@ if args.exit_immediately:
     boinc_process.send_signal(signal.SIGTERM)
     boinc_process.wait()
 
-# Reconciling the configured projects happens once, at startup: Home Assistant cannot apply an
-# options change without restarting the app, so there is nothing new to read afterwards. The only
-# reason left to wake up is an attach that failed, and only until it succeeds.
-retry_delay = RETRY_INITIAL_DELAY
-next_retry = monotonic() + retry_delay
-
-while pending_projects and boinc_process.poll() is None:
-    sleep(0.5)
-    if monotonic() >= next_retry:
-        pending_projects = configure_projects(data_folder, options.get('projects'))
-        retry_delay = min(retry_delay * 2, RETRY_MAX_DELAY)
-        next_retry = monotonic() + retry_delay
-
-# With nothing left to retry, block on the client rather than polling it: wait() with no timeout is
-# a blocking waitpid(), while wait(timeout=...) is a busy loop sleeping up to 50ms a turn -- worse
-# than the sleep(0.5) this replaces. It returns immediately if the client is already gone.
+# Everything is configured by this point, so block on the client rather than polling it. Keep this
+# a bare wait(): with no timeout it is a blocking waitpid(), while wait(timeout=...) is a busy loop
+# sleeping up to 50ms a turn -- worse than the sleep(0.5) it replaced -- so anything that needs to
+# wake up periodically here has to be built some other way. It returns immediately if the client is
+# already gone.
 boinc_process.wait()
 
 logging.debug(f'BOINC client stopped with code {boinc_process.returncode}')

--- a/boinc/operator/projects.py
+++ b/boinc/operator/projects.py
@@ -25,7 +25,11 @@ def validate_projects(projects: list[dict] | None, account_manager_url: str | No
     if not projects:
         return True
 
-    if account_manager_url is not None:
+    # Truthiness, not `is not None`, so an empty string counts as unset exactly the way
+    # configure_boinc_projects reads it. The two would otherwise disagree about what "configured"
+    # means, and today they only agree because the schema types this option `url?` and rejects an
+    # empty string -- an accident of the schema, not a decision this module makes.
+    if account_manager_url:
         # An account manager owns the project list and re-asserts it on every sync, so the two
         # would undo each other on a loop for as long as the app ran. Like half an account manager,
         # this has no safe reading, so it stops the app instead of oscillating quietly.

--- a/boinc/operator/projects.py
+++ b/boinc/operator/projects.py
@@ -1,0 +1,191 @@
+import json
+import logging
+import os
+import subprocess
+
+from url import canonicalize_url
+
+# What the operator attached on a previous run. BOINC cannot record this for us: a project carries
+# no label saying who attached it, so without this file one the user attached from boinctui would be
+# indistinguishable from one the operator attached and the user then removed from the options --
+# and the removal branch below would destroy it. Same pattern as .managed_global_prefs.json.
+MANAGED_STATE_FILE = '.managed_projects.json'
+
+# Projects the operator attached and still owns, and projects it has asked the client to leave once
+# their work is done. The second list cannot be derived from the client: detach_when_done is not
+# among the fields --get_project_status prints, so a pending detach is invisible from outside.
+MANAGED_ATTACHED = 'attached'
+MANAGED_DETACHING = 'detaching'
+
+# Backoff for a project whose attach failed, in seconds. Attaching is a local RPC, so this covers a
+# client that is not answering yet rather than a project that is down -- the client retries the
+# project's own scheduler by itself, indefinitely, and does it better than the operator could.
+RETRY_INITIAL_DELAY = 30
+RETRY_MAX_DELAY = 1800
+
+
+def run_boinccmd(data_folder: str, arguments: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(["boinccmd", *arguments], capture_output=True, text=True, cwd=data_folder)
+
+def validate_projects(projects: list[dict] | None, account_manager_url: str | None) -> bool:
+    if not projects:
+        return True
+
+    if account_manager_url is not None:
+        # An account manager owns the project list and re-asserts it on every sync, so the two
+        # would undo each other on a loop for as long as the app ran. Like half an account manager,
+        # this has no safe reading, so it stops the app instead of oscillating quietly.
+        logging.error(f'Conflicting configuration: projects cannot be listed while account_manager_url is set, because the account manager decides which projects are attached')
+        return False
+
+    seen = set()
+    for project in projects:
+        url = project.get('url')
+        if not url or not project.get('account_key'):
+            logging.error(f'Incomplete project configuration: every project needs both url and account_key')
+            return False
+
+        url = canonicalize_url(url)
+        if url in seen:
+            # Two entries for one project with different keys have no safe reading either: whichever
+            # the operator picked would look arbitrary the first time it mattered.
+            logging.error(f'Duplicated project {url}: list each project once')
+            return False
+        seen.add(url)
+
+    return True
+
+def read_attached_projects(data_folder: str) -> dict[str, bool] | None:
+    """Every attached project, keyed by canonicalized master URL, mapped to whether an account
+    manager attached it. Returns None when the client could not be asked at all."""
+    result = run_boinccmd(data_folder, ["--get_project_status"])
+    if result.returncode != 0:
+        logging.error(f'Failed to get project status: {result.stderr}')
+        return None
+
+    logging.debug(f'{result.stdout}')
+
+    projects = {}
+    url = None
+    for line in result.stdout.splitlines():
+        name, separator, value = line.partition(':')
+        if not separator:
+            continue
+
+        name = name.strip()
+        value = value.strip()
+
+        if name == 'master URL':
+            # The client stores the URL already canonicalized, but canonicalizing again is what
+            # makes it comparable to a URL typed into the options.
+            url = canonicalize_url(value)
+            projects[url] = False
+        elif name == 'attached via Account Manager' and url is not None:
+            projects[url] = value == 'yes'
+
+    return projects
+
+def read_managed_state(data_folder: str) -> dict[str, set[str]]:
+    state_file = f'{data_folder}/{MANAGED_STATE_FILE}'
+    empty = {MANAGED_ATTACHED: set(), MANAGED_DETACHING: set()}
+
+    if not os.path.exists(state_file):
+        return empty
+
+    try:
+        with open(state_file, 'r') as f:
+            state = json.load(f)
+    except (OSError, ValueError) as error:
+        logging.warning(f'Ignoring unreadable {MANAGED_STATE_FILE}: {error}')
+        return empty
+
+    if not isinstance(state, dict):
+        logging.warning(f'Ignoring {MANAGED_STATE_FILE}, expected an object')
+        return empty
+
+    # An unreadable half means "the operator never attached this", which only ever makes the
+    # removal branch do less. Erring the other way could detach a project it does not own.
+    return {key: {url for url in state.get(key, []) if isinstance(url, str)} for key in empty}
+
+def write_managed_state(data_folder: str, state: dict[str, set[str]]) -> None:
+    with open(f'{data_folder}/{MANAGED_STATE_FILE}', 'w') as f:
+        json.dump({key: sorted(urls) for key, urls in state.items()}, f, indent=2, sort_keys=True)
+
+def attach_project(data_folder: str, url: str, account_key: str) -> bool:
+    logging.info(f'Attaching project {url}')
+    result = run_boinccmd(data_folder, ["--project_attach", url, account_key])
+    if result.returncode != 0:
+        logging.warning(f'Failed to attach project {url}, retrying later: {result.stderr.strip() or result.stdout.strip()}')
+        return False
+
+    logging.debug(result.stdout)
+    logging.info(f'Project {url} attached')
+    return True
+
+def project_operation(data_folder: str, url: str, operation: str) -> bool:
+    result = run_boinccmd(data_folder, ["--project", url, operation])
+    if result.returncode != 0:
+        logging.error(f'Failed to {operation} project {url}: {result.stderr.strip() or result.stdout.strip()}')
+        return False
+
+    logging.debug(result.stdout)
+    return True
+
+def configure_projects(data_folder: str, projects: list[dict] | None) -> list[str]:
+    """Reconcile the attached projects against the configured ones, returning the projects that
+    still need attaching so the caller can try them again later."""
+    desired = {canonicalize_url(project['url']): project['account_key'] for project in projects or []}
+    managed = read_managed_state(data_folder)
+
+    if not desired and not managed[MANAGED_ATTACHED] and not managed[MANAGED_DETACHING]:
+        # Nothing configured and nothing ever attached by the operator: the overwhelmingly common
+        # case, and the one where asking the client anything at all would be pure cost.
+        return []
+
+    statuses = read_attached_projects(data_folder)
+    if statuses is None:
+        # Without the current state there is no diff to compute, and acting blind could attach a
+        # project twice or detach one the operator does not own. Try the whole thing again later.
+        return sorted(desired)
+
+    # A project an account manager attached belongs to the account manager, which re-asserts its
+    # list on every sync. Touching it here would start exactly the loop validate_projects refuses.
+    account_manager_owned = {url for url, via_account_manager in statuses.items() if via_account_manager}
+    attached = set(statuses) - account_manager_owned
+
+    for url in sorted(desired.keys() & account_manager_owned):
+        logging.warning(f'Ignoring project {url}: it is attached by an account manager, which decides on its own which projects are attached')
+
+    # Configured again after being left to drain, so undo both halves of detach_when_done. The
+    # client clears its no-more-work flag with the detach flag, but saying so explicitly costs one
+    # local RPC and does not depend on that.
+    for url in sorted(managed[MANAGED_DETACHING] & desired.keys() & attached):
+        logging.info(f'Project {url} is configured again, cancelling its pending detach')
+        project_operation(data_folder, url, 'dont_detach_when_done')
+        project_operation(data_folder, url, 'allowmorework')
+
+    # Only a project the operator attached itself may be detached, and only while it is still
+    # there: boinccmd fails outright on a project the user already detached by hand. A project
+    # already draining stays in the set so the flag is re-asserted rather than assumed.
+    owned = managed[MANAGED_ATTACHED] | managed[MANAGED_DETACHING]
+    detaching = (owned - desired.keys()) & attached
+    for url in sorted(detaching):
+        logging.info(f'Project {url} is no longer configured, detaching it once its current work is done')
+        project_operation(data_folder, url, 'detach_when_done')
+
+    attached_now = set()
+    pending = []
+    for url in sorted(desired.keys() - attached - account_manager_owned):
+        if attach_project(data_folder, url, desired[url]):
+            attached_now.add(url)
+        else:
+            pending.append(url)
+
+    write_managed_state(data_folder, {
+        MANAGED_ATTACHED: (desired.keys() & attached) | attached_now,
+        # Already intersected with what is attached, so an entry disappears on the run after the
+        # client actually lets the project go instead of lingering forever.
+        MANAGED_DETACHING: detaching,
+    })
+
+    return pending

--- a/boinc/operator/projects.py
+++ b/boinc/operator/projects.py
@@ -17,12 +17,6 @@ MANAGED_STATE_FILE = '.managed_projects.json'
 MANAGED_ATTACHED = 'attached'
 MANAGED_DETACHING = 'detaching'
 
-# Backoff for a project whose attach failed, in seconds. Attaching is a local RPC, so this covers a
-# client that is not answering yet rather than a project that is down -- the client retries the
-# project's own scheduler by itself, indefinitely, and does it better than the operator could.
-RETRY_INITIAL_DELAY = 30
-RETRY_MAX_DELAY = 1800
-
 
 def run_boinccmd(data_folder: str, arguments: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(["boinccmd", *arguments], capture_output=True, text=True, cwd=data_folder)
@@ -115,7 +109,7 @@ def attach_project(data_folder: str, url: str, account_key: str) -> bool:
     logging.info(f'Attaching project {url}')
     result = run_boinccmd(data_folder, ["--project_attach", url, account_key])
     if result.returncode != 0:
-        logging.warning(f'Failed to attach project {url}, retrying later: {result.stderr.strip() or result.stdout.strip()}')
+        logging.warning(f'Failed to attach project {url}, it will be attempted again when the app restarts: {result.stderr.strip() or result.stdout.strip()}')
         return False
 
     logging.debug(result.stdout)
@@ -133,7 +127,8 @@ def project_operation(data_folder: str, url: str, operation: str) -> bool:
 
 def configure_projects(data_folder: str, projects: list[dict] | None) -> list[str]:
     """Reconcile the attached projects against the configured ones, returning the projects that
-    still need attaching so the caller can try them again later."""
+    could not be attached. Reconciling happens once per start, so that list is what to report
+    rather than what to retry: nothing else will act on it until the app restarts."""
     desired = {canonicalize_url(project['url']): project['account_key'] for project in projects or []}
     managed = read_managed_state(data_folder)
 
@@ -145,7 +140,7 @@ def configure_projects(data_folder: str, projects: list[dict] | None) -> list[st
     statuses = read_attached_projects(data_folder)
     if statuses is None:
         # Without the current state there is no diff to compute, and acting blind could attach a
-        # project twice or detach one the operator does not own. Try the whole thing again later.
+        # project twice or detach one the operator does not own. Nothing configured got applied.
         return sorted(desired)
 
     # A project an account manager attached belongs to the account manager, which re-asserts its

--- a/boinc/operator/redact.py
+++ b/boinc/operator/redact.py
@@ -1,6 +1,26 @@
 SECRET_OPTIONS = ('gui_rpc_password', 'account_manager_password')
 
+# Secrets nested inside a list-of-dict option, which the flat pass over the top level cannot reach.
+# Missing one here means it reaches the DEBUG dump, and CI runs the image at DEBUG, so every build's
+# public log would carry it.
+SECRET_LIST_OPTIONS = {'projects': ('account_key',)}
+
 REDACTED = '***'
 
+def redact_entry(entry, secrets: tuple) -> dict:
+    if not isinstance(entry, dict):
+        return entry
+    return {key: REDACTED if key in secrets and value is not None else value for key, value in entry.items()}
+
 def redact_secrets(options: dict) -> dict:
-    return {key: REDACTED if key in SECRET_OPTIONS and value is not None else value for key, value in options.items()}
+    redacted = {}
+
+    for key, value in options.items():
+        if key in SECRET_OPTIONS and value is not None:
+            redacted[key] = REDACTED
+        elif key in SECRET_LIST_OPTIONS and isinstance(value, list):
+            redacted[key] = [redact_entry(entry, SECRET_LIST_OPTIONS[key]) for entry in value]
+        else:
+            redacted[key] = value
+
+    return redacted

--- a/boinc/operator/test/test_boinccmd.py
+++ b/boinc/operator/test/test_boinccmd.py
@@ -81,9 +81,8 @@ class ConfigureBoincProjectsTestCase(unittest.TestCase):
 
         self.assertEqual(executed_commands(run), [['--acct_mgr', 'info'], ['--acct_mgr', 'sync']])
 
-    @patch('boinccmd.sleep')
     @patch('boinccmd.subprocess.run')
-    def test_should_replace_an_account_manager_on_the_same_host_with_a_different_path(self, run, sleep):
+    def test_should_replace_an_account_manager_on_the_same_host_with_a_different_path(self, run):
         # Only comparing the host (the old netloc-only comparison) would have called this the same
         # account manager and synced against the wrong one.
         run.side_effect = [account_manager_info('https://host/a'), completed(), completed()]
@@ -96,9 +95,8 @@ class ConfigureBoincProjectsTestCase(unittest.TestCase):
             ['--acct_mgr', 'attach', 'https://host/b', ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD],
         ])
 
-    @patch('boinccmd.sleep')
     @patch('boinccmd.subprocess.run')
-    def test_should_replace_a_different_account_manager(self, run, sleep):
+    def test_should_replace_a_different_account_manager(self, run):
         run.side_effect = [account_manager_info('https://another.account.manager'), completed(), completed()]
 
         self.assertTrue(configure_boinc_projects('a data folder', ACCOUNT_MANAGER_URL, ACCOUNT_MANAGER_USERNAME, ACCOUNT_MANAGER_PASSWORD))

--- a/boinc/operator/test/test_main.py
+++ b/boinc/operator/test/test_main.py
@@ -225,6 +225,19 @@ class MainTestCase(unittest.TestCase):
         self.assertEqual(self.read_signal(), 'TERM')
         self.assertNotIn('failed to configure', self.log_contents())
 
+    def test_operator_stops_when_the_client_never_answers(self):
+        # --get_state always failing stands in for a client that starts but never answers RPCs.
+        # Unbounded, this used to spawn boinccmd twice a second forever while Home Assistant showed
+        # the app as started.
+        self.start_operator('--initialization-timeout', '1', env={'FAKE_BOINCCMD_GET_STATE_FAIL': '1'})
+        self.proc.wait(timeout=15)
+
+        self.assertEqual(self.proc.returncode, 1)
+        self.assertEqual(self.read_signal(), 'TERM')
+        # The client is what failed, so the log must not blame the configuration for it.
+        self.assertIn('never became reachable', self.log_contents())
+        self.assertNotIn('failed to configure', self.log_contents())
+
     def test_configured_projects_are_attached(self):
         self.write_options({'projects': [{'url': 'https://einsteinathome.org/', 'account_key': 'a key'}]})
 

--- a/boinc/operator/test/test_main.py
+++ b/boinc/operator/test/test_main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import signal
 import stat
@@ -42,6 +43,13 @@ FAKE_BOINC = textwrap.dedent("""\
 FAKE_BOINCCMD = textwrap.dedent("""\
     #!/usr/bin/env bash
     set -u
+
+    echo "$*" >> "$BOINCCMD_LOG_FILE"
+
+    if [ "$1" = "--get_project_status" ]; then
+        echo "======== Projects ========"
+        exit 0
+    fi
 
     if [ "$1" = "--get_state" ]; then
         if [ -n "${FAKE_BOINCCMD_GET_STATE_FAIL:-}" ]; then
@@ -96,11 +104,13 @@ class MainTestCase(unittest.TestCase):
 
         self.marker_file = base / 'boinc-started'
         self.signal_file = base / 'boinc-signal'
+        self.boinccmd_log_file = base / 'boinccmd-commands'
 
         self.env = dict(os.environ)
         self.env['PATH'] = f'{bin_dir}{os.pathsep}{self.env.get("PATH", "")}'
         self.env['BOINC_MARKER_FILE'] = str(self.marker_file)
         self.env['BOINC_SIGNAL_FILE'] = str(self.signal_file)
+        self.env['BOINCCMD_LOG_FILE'] = str(self.boinccmd_log_file)
 
         self.proc = None
 
@@ -158,6 +168,12 @@ class MainTestCase(unittest.TestCase):
     def read_signal(self) -> str:
         return self.signal_file.read_text().strip()
 
+    def boinccmd_commands(self) -> list[str]:
+        return self.boinccmd_log_file.read_text().splitlines() if self.boinccmd_log_file.exists() else []
+
+    def write_options(self, options: dict) -> None:
+        self.options_file.write_text(json.dumps(options))
+
     def test_exit_immediately_flag_takes_no_value_and_stops_the_client(self):
         self.start_operator('--exit-immediately')
         self.wait_for_marker()
@@ -208,6 +224,32 @@ class MainTestCase(unittest.TestCase):
         self.assertEqual(self.proc.returncode, 0)
         self.assertEqual(self.read_signal(), 'TERM')
         self.assertNotIn('failed to configure', self.log_contents())
+
+    def test_configured_projects_are_attached(self):
+        self.write_options({'projects': [{'url': 'https://einsteinathome.org/', 'account_key': 'a key'}]})
+
+        self.start_operator('--exit-immediately')
+        self.proc.wait(timeout=10)
+
+        self.assertEqual(self.proc.returncode, 0)
+        self.assertIn('--project_attach https://einsteinathome.org/ a key', self.boinccmd_commands())
+
+    def test_projects_alongside_an_account_manager_stop_the_operator_before_it_starts_anything(self):
+        self.write_options({
+            'account_manager_url': 'https://scienceunited.org',
+            'account_manager_username': 'a username',
+            'account_manager_password': 'a password',
+            'projects': [{'url': 'https://einsteinathome.org/', 'account_key': 'a key'}],
+        })
+
+        self.start_operator()
+        self.proc.wait(timeout=10)
+
+        self.assertEqual(self.proc.returncode, 1)
+        # A contradiction between the options needs no client to answer it, so it is caught before
+        # the client is launched rather than after.
+        self.assertFalse(self.marker_file.exists())
+        self.assertEqual(self.boinccmd_commands(), [])
 
 
 if __name__ == '__main__':

--- a/boinc/operator/test/test_projects.py
+++ b/boinc/operator/test/test_projects.py
@@ -220,7 +220,9 @@ class ConfigureProjectsTestCase(unittest.TestCase):
         self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [], MANAGED_DETACHING: []})
 
     @patch('projects.subprocess.run')
-    def test_should_report_a_project_it_could_not_attach_for_a_later_retry(self, run):
+    def test_should_report_a_project_it_could_not_attach(self, run):
+        # Reported rather than retried: nothing acts on this until the app restarts, so it has to
+        # reach the log where the user can see it.
         run.side_effect = [project_status(), completed(returncode=1)]
 
         self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [EINSTEIN])
@@ -243,7 +245,7 @@ class ConfigureProjectsTestCase(unittest.TestCase):
         self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: []})
 
     @patch('projects.subprocess.run')
-    def test_should_retry_everything_when_the_client_cannot_be_asked(self, run):
+    def test_should_report_everything_when_the_client_cannot_be_asked(self, run):
         # Without the current state there is no diff to compute, and acting blind could attach a
         # project twice or detach one the operator does not own.
         run.side_effect = [completed(returncode=1)]

--- a/boinc/operator/test/test_projects.py
+++ b/boinc/operator/test/test_projects.py
@@ -158,6 +158,21 @@ class ConfigureProjectsTestCase(unittest.TestCase):
         self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: []})
 
     @patch('projects.subprocess.run')
+    def test_should_keep_a_project_managed_when_its_detach_fails(self, run):
+        # The detach flag cannot be read back from the client, so dropping the project from the
+        # state file here would leave it attached with nothing left to ask about it ever again.
+        run.side_effect = [project_status(EINSTEIN, ROSETTA), completed(returncode=1)]
+        self.write_managed_state(attached=[EINSTEIN, ROSETTA])
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project', ROSETTA, 'detach_when_done'],
+        ])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: [ROSETTA]})
+
+    @patch('projects.subprocess.run')
     def test_should_keep_asking_for_a_detach_until_the_client_lets_the_project_go(self, run):
         run.side_effect = [project_status(ROSETTA), completed()]
         self.write_managed_state(detaching=[ROSETTA])

--- a/boinc/operator/test/test_projects.py
+++ b/boinc/operator/test/test_projects.py
@@ -60,6 +60,11 @@ class ValidateProjectsTestCase(unittest.TestCase):
         # undoing each other for as long as the app ran.
         self.assertFalse(validate_projects(configured(EINSTEIN), 'https://scienceunited.org'))
 
+    def test_should_accept_projects_when_the_account_manager_url_is_empty(self):
+        # configure_boinc_projects reads an empty string as "not configured"; disagreeing here
+        # would refuse to start a projects-only configuration that it considers perfectly valid.
+        self.assertTrue(validate_projects(configured(EINSTEIN), ''))
+
     def test_should_reject_a_project_without_an_account_key(self):
         self.assertFalse(validate_projects([{'url': EINSTEIN}], None))
 

--- a/boinc/operator/test/test_projects.py
+++ b/boinc/operator/test/test_projects.py
@@ -1,0 +1,269 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from projects import MANAGED_ATTACHED, MANAGED_DETACHING, MANAGED_STATE_FILE, configure_projects, validate_projects
+
+EINSTEIN = 'https://einsteinathome.org/'
+ROSETTA = 'https://boinc.bakerlab.org/rosetta/'
+WORLD_COMMUNITY_GRID = 'https://www.worldcommunitygrid.org/'
+
+ACCOUNT_KEY = 'an account key'
+
+
+def completed(stdout: str = '', returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr='')
+
+
+def project_status(*projects) -> subprocess.CompletedProcess:
+    """Reproduce what `boinccmd --get_project_status` prints, field for field, including the two
+    lines this module reads and the surrounding ones it must skip -- `last RPC` in particular has a
+    value full of colons, and `name` an empty one."""
+    lines = ['======== Projects ========']
+    for index, project in enumerate(projects, start=1):
+        url = project if isinstance(project, str) else project[0]
+        via_account_manager = 'no' if isinstance(project, str) else project[1]
+        lines += [
+            f'{index}) -----------',
+            '   name: ',
+            f'   master URL: {url}',
+            '   resource share: 100.000000',
+            f'   attached via Account Manager: {via_account_manager}',
+            "   don't request more work: no",
+            '   last RPC: Thu Jan  1 00:00:00 1970',
+        ]
+    return completed('\n'.join(lines) + '\n')
+
+
+def executed_commands(run) -> list:
+    return [call.args[0][1:] for call in run.call_args_list]
+
+
+def configured(*urls) -> list[dict]:
+    return [{'url': url, 'account_key': ACCOUNT_KEY} for url in urls]
+
+
+class ValidateProjectsTestCase(unittest.TestCase):
+
+    def test_should_accept_no_projects(self):
+        self.assertTrue(validate_projects(None, None))
+        self.assertTrue(validate_projects([], None))
+
+    def test_should_accept_no_projects_alongside_an_account_manager(self):
+        self.assertTrue(validate_projects([], 'https://scienceunited.org'))
+
+    def test_should_reject_projects_alongside_an_account_manager(self):
+        # An account manager re-asserts its own project list on every sync, so the two would keep
+        # undoing each other for as long as the app ran.
+        self.assertFalse(validate_projects(configured(EINSTEIN), 'https://scienceunited.org'))
+
+    def test_should_reject_a_project_without_an_account_key(self):
+        self.assertFalse(validate_projects([{'url': EINSTEIN}], None))
+
+    def test_should_reject_a_project_without_a_url(self):
+        self.assertFalse(validate_projects([{'account_key': ACCOUNT_KEY}], None))
+
+    def test_should_reject_the_same_project_listed_twice(self):
+        # Canonicalized, so these two spellings are one project with two different keys, and
+        # choosing either would look arbitrary the first time it mattered.
+        projects = [
+            {'url': 'https://einsteinathome.org', 'account_key': 'one key'},
+            {'url': 'https://einsteinathome.org/', 'account_key': 'another key'},
+        ]
+
+        self.assertFalse(validate_projects(projects, None))
+
+
+class ConfigureProjectsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.data_folder = directory.name
+
+    def write_managed_state(self, attached=(), detaching=()) -> None:
+        state = {MANAGED_ATTACHED: list(attached), MANAGED_DETACHING: list(detaching)}
+        Path(self.data_folder, MANAGED_STATE_FILE).write_text(json.dumps(state))
+
+    def managed_state(self) -> dict:
+        return json.loads(Path(self.data_folder, MANAGED_STATE_FILE).read_text())
+
+    @patch('projects.subprocess.run')
+    def test_should_not_ask_the_client_anything_when_nothing_is_configured(self, run):
+        # The overwhelmingly common case: an install that never used this option should not pay an
+        # RPC for it on every start.
+        self.assertEqual(configure_projects(self.data_folder, None), [])
+
+        self.assertEqual(executed_commands(run), [])
+        self.assertFalse(Path(self.data_folder, MANAGED_STATE_FILE).exists())
+
+    @patch('projects.subprocess.run')
+    def test_should_attach_a_configured_project(self, run):
+        run.side_effect = [project_status(), completed()]
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project_attach', EINSTEIN, ACCOUNT_KEY],
+        ])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_leave_an_already_attached_project_alone(self, run):
+        run.side_effect = [project_status(EINSTEIN)]
+        self.write_managed_state(attached=[EINSTEIN])
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+
+    @patch('projects.subprocess.run')
+    def test_should_match_a_project_whose_url_is_spelled_differently(self, run):
+        # The client reports the canonicalized master URL, so a URL typed without its scheme or
+        # trailing slash is the same project, not a second one to attach.
+        run.side_effect = [project_status(EINSTEIN)]
+        self.write_managed_state(attached=[EINSTEIN])
+
+        self.assertEqual(configure_projects(self.data_folder, configured('https://einsteinathome.org')), [])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+
+    @patch('projects.subprocess.run')
+    def test_should_detach_a_project_it_attached_once_it_is_no_longer_configured(self, run):
+        run.side_effect = [project_status(EINSTEIN, ROSETTA), completed()]
+        self.write_managed_state(attached=[EINSTEIN, ROSETTA])
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project', ROSETTA, 'detach_when_done'],
+        ])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: [ROSETTA]})
+
+    @patch('projects.subprocess.run')
+    def test_should_never_detach_a_project_it_did_not_attach(self, run):
+        # Attached from boinctui or a remote BOINC Manager: without the managed state file this
+        # would be indistinguishable from one the operator attached and the user then removed.
+        run.side_effect = [project_status(EINSTEIN, WORLD_COMMUNITY_GRID)]
+        self.write_managed_state(attached=[EINSTEIN])
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_keep_asking_for_a_detach_until_the_client_lets_the_project_go(self, run):
+        run.side_effect = [project_status(ROSETTA), completed()]
+        self.write_managed_state(detaching=[ROSETTA])
+
+        self.assertEqual(configure_projects(self.data_folder, None), [])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project', ROSETTA, 'detach_when_done'],
+        ])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [], MANAGED_DETACHING: [ROSETTA]})
+
+    @patch('projects.subprocess.run')
+    def test_should_forget_a_project_the_client_has_finished_detaching(self, run):
+        run.side_effect = [project_status()]
+        self.write_managed_state(detaching=[ROSETTA])
+
+        self.assertEqual(configure_projects(self.data_folder, None), [])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_cancel_a_pending_detach_when_the_project_is_configured_again(self, run):
+        # detach_when_done is not among the fields --get_project_status prints, so nothing but the
+        # state file can tell that this project was on its way out.
+        run.side_effect = [project_status(ROSETTA), completed(), completed()]
+        self.write_managed_state(detaching=[ROSETTA])
+
+        self.assertEqual(configure_projects(self.data_folder, configured(ROSETTA)), [])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project', ROSETTA, 'dont_detach_when_done'],
+            ['--project', ROSETTA, 'allowmorework'],
+        ])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [ROSETTA], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_reattach_a_project_detached_outside_the_options(self, run):
+        run.side_effect = [project_status(), completed()]
+        self.write_managed_state(attached=[EINSTEIN])
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project_attach', EINSTEIN, ACCOUNT_KEY],
+        ])
+
+    @patch('projects.subprocess.run')
+    def test_should_leave_a_project_an_account_manager_attached_alone(self, run):
+        # The account manager re-asserts its list on every sync, so attaching or detaching here
+        # would start exactly the loop validate_projects refuses to allow.
+        run.side_effect = [project_status((EINSTEIN, 'yes'))]
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_report_a_project_it_could_not_attach_for_a_later_retry(self, run):
+        run.side_effect = [project_status(), completed(returncode=1)]
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [EINSTEIN])
+
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_attach_the_other_projects_when_one_of_them_fails(self, run):
+        # Projects are attached in sorted URL order, so ROSETTA is the one that meets the failure
+        # here. One project failing must not cost the others their attach.
+        run.side_effect = [project_status(), completed(returncode=1), completed()]
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN, ROSETTA)), [ROSETTA])
+
+        self.assertEqual(executed_commands(run), [
+            ['--get_project_status'],
+            ['--project_attach', ROSETTA, ACCOUNT_KEY],
+            ['--project_attach', EINSTEIN, ACCOUNT_KEY],
+        ])
+        self.assertEqual(self.managed_state(), {MANAGED_ATTACHED: [EINSTEIN], MANAGED_DETACHING: []})
+
+    @patch('projects.subprocess.run')
+    def test_should_retry_everything_when_the_client_cannot_be_asked(self, run):
+        # Without the current state there is no diff to compute, and acting blind could attach a
+        # project twice or detach one the operator does not own.
+        run.side_effect = [completed(returncode=1)]
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [EINSTEIN])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+        self.assertFalse(Path(self.data_folder, MANAGED_STATE_FILE).exists())
+
+    @patch('projects.subprocess.run')
+    def test_should_ignore_an_unreadable_managed_state_file(self, run):
+        # Erring towards "the operator never attached this" only ever makes the removal branch do
+        # less; erring the other way could detach a project it does not own.
+        Path(self.data_folder, MANAGED_STATE_FILE).write_text('not json at all')
+        run.side_effect = [project_status(EINSTEIN)]
+
+        self.assertEqual(configure_projects(self.data_folder, configured(EINSTEIN)), [])
+
+        self.assertEqual(executed_commands(run), [['--get_project_status']])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/boinc/operator/test/test_redact.py
+++ b/boinc/operator/test/test_redact.py
@@ -45,6 +45,29 @@ class RedactTestCase(unittest.TestCase):
 
         self.assertEqual(options, {'gui_rpc_password': 'a gui rpc password'})
 
+    def test_should_redact_the_account_key_of_every_project(self):
+        # Nested inside a list, where the flat pass over the top level cannot reach it. CI runs the
+        # image at DEBUG, so a miss here would put every user's key in a public build log.
+        options = {'projects': [
+            {'url': 'https://einsteinathome.org/', 'account_key': 'a key'},
+            {'url': 'https://boinc.bakerlab.org/rosetta/', 'account_key': 'another key'},
+        ]}
+
+        self.assertEqual(redact_secrets(options), {'projects': [
+            {'url': 'https://einsteinathome.org/', 'account_key': '***'},
+            {'url': 'https://boinc.bakerlab.org/rosetta/', 'account_key': '***'},
+        ]})
+
+    def test_should_not_modify_the_original_projects(self):
+        options = {'projects': [{'url': 'https://einsteinathome.org/', 'account_key': 'a key'}]}
+
+        redact_secrets(options)
+
+        self.assertEqual(options, {'projects': [{'url': 'https://einsteinathome.org/', 'account_key': 'a key'}]})
+
+    def test_should_keep_an_empty_project_list(self):
+        self.assertEqual(redact_secrets({'projects': []}), {'projects': []})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/boinc/translations/en.yaml
+++ b/boinc/translations/en.yaml
@@ -1,4 +1,7 @@
 configuration:
+  projects:
+    name: Projects
+    description: "The science projects to compute for, each with its address and your account key for it. Cannot be combined with the account manager options; setting both stops the app from starting"
   gui_rpc_password:
     name: "GUI RPC password"
     description: "Password to control this BOINC client remotely, e.g. from boinctui. Set one if you plan to connect remotely — see the app documentation for what leaving it empty does"

--- a/boinc/translations/es.yaml
+++ b/boinc/translations/es.yaml
@@ -1,4 +1,7 @@
 configuration:
+  projects:
+    name: Proyectos
+    description: "Los proyectos científicos para los que computar, cada uno con su dirección y tu clave de cuenta en él. No se puede combinar con las opciones del Gestor de Cuentas: si configuras ambas cosas, la app no arranca"
   gui_rpc_password:
     name: "Contraseña GUI RPC"
     description: "Contraseña para controlar este cliente BOINC de forma remota, por ejemplo desde boinctui. Configúrala si vas a conectarte de forma remota — consulta la documentación de la app para saber qué ocurre si la dejas vacía"


### PR DESCRIPTION
Adds a `projects` list to the BOINC app's configuration, so the projects to compute for can be
chosen directly instead of only through an account manager. `boinc` 3.10.0.

```yaml
projects:
  - url: "https://einsteinathome.org/"
    account_key: "your account key for this project"
```

## The hard part is removal, not attachment

A project carries no marker saying who attached it, so `actual − desired` must never map to a
removal — the first restart would destroy a project attached from boinctui. New
`boinc/operator/projects.py` reconciles three sets instead:

| Set | Source |
|---|---|
| `desired` | the option, canonicalized through `url.py` |
| `actual` | `boinccmd --get_project_status` |
| `managed` | `.managed_projects.json`, the *kubectl apply* pattern `global_prefs_override.py` already uses |

Only what the operator attached itself can ever be removed, and removal is `detach_when_done`, so
BOINC finishes and reports the work it already downloaded before leaving. A bare `detach` aborts
in-progress tasks and deletes downloaded files.

The state file needs **two** lists, `attached` and `detaching`, because `detach_when_done` is not
among the fields `--get_project_status` prints. A pending detach is invisible from outside, so a
project removed and then re-added would otherwise have its detach fire silently days later.

## Decisions worth arguing with

- **Account key, not email + password.** This removes `--lookup_account` entirely, and with it two
  traps in BOINC 8.2.15: it takes its exit code from the *initial* RPC rather than the poll, so a
  failed lookup prints `poll status: can't resolve hostname` and still **exits 0**; and its poll
  loop has neither a sleep nor a break when the poll RPC itself errors. It also keeps a second
  password out of the options.
- **An account manager is refused, not merged.** It owns the project list and re-asserts it on every
  sync, so both together would undo each other indefinitely. Refused before the client is launched.
- **Reconciliation runs at startup only**, since Home Assistant cannot apply an options change
  without restarting the app. A project detached outside the options therefore comes back on the
  next start, deliberately — the list is the declaration. `DOCS.md` says so.
- **No retry at all.** `--project_attach` is a *local* RPC that returns instantly and persists even
  against an unresolvable host, after which the client retries the project's scheduler by itself —
  so "the project is down" was never the operator's problem. That left "the client is not answering
  yet", and the initialization loop already closes that window, since `configure_projects` runs only
  after `boinccmd --get_state` has succeeded. A bounded backoff was written first and then deleted:
  it guarded a case that cannot arise. A failed attach is a warning naming the projects, retried
  when the app restarts.
- **The initialization loop is bounded now.** It had no deadline, so a client that starts but never
  answers RPCs left the operator spawning `boinccmd` twice a second forever while Home Assistant
  reported the app as started. It gives up after `--initialization-timeout` (300 s), stops the
  client and exits 1 naming the client rather than the configuration. Its probe also moved before
  the first sleep, so a normal start no longer pays the interval for nothing.
- **Nothing polls after startup.** `main.py` ends on a bare `boinc_process.wait()` — with no timeout
  that is a blocking `waitpid()`, while `wait(timeout=...)` is an explicit busy loop sleeping up to
  50 ms a turn, *worse* than the `sleep(0.5)` it replaces. Measured on a running container, the
  operator sits at `Threads: 1`, `State: S (sleeping)`. The one `sleep` left is the bounded
  initialization loop above. Removing even that with inotify was evaluated and rejected on price:
  BOINC does `bind()` a Unix domain socket before the TCP one, so a blocking primitive genuinely
  exists — it just costs a Dockerfile dependency and two race conditions to save three `boinccmd`
  spawns once per start. The reasoning is in `TODO.md` so it is not re-derived.

`redact.py` had to learn to reach inside a list, or every build's public log would carry the account
keys, since CI runs the image at DEBUG.

## Second commit: a ten second wait that was never needed

`--acct_mgr detach` is `rpc.acct_mgr_rpc("", "", "")`, a single synchronous RPC, so the `sleep(10)`
before attaching the replacement waited for something already done. It also produced a **misleading
`exit 1`**: `time.sleep()` is resumed after a signal handler runs rather than cut short (PEP 475,
measured — handler at 0.31 s, `sleep(3)` still returning at 3.01 s), so a stop in that window ended
in an attach against a dead client. `main.py` now re-checks for a stop *after*
`configure_boinc_projects` returns.

## Testing

100 unit tests pass on the Python that actually ships (3.13.5, run inside the built image).

Verified end to end against a real BOINC client, not only in unit tests: attach with URL
canonicalization, removal → `detach_when_done`, a hand-attached project left untouched, the state
file clearing once the client lets a project go, re-add re-attaching, and the account manager
conflict exiting 1 without starting BOINC.

**Also verified under a real Supervisor**, which is the half CI cannot see. Supervisor parses the
option as `type: schema` / `multiple: true`, with `url` carrying `format: url` and `account_key`
`format: password`; both translations render; and the `options: projects: []` default lets a fresh
install validate.

The half worth having is the rejection — **at tier 1, before the container starts, with the message
shown in the UI**:

| Sent | Supervisor's answer |
|---|---|
| `url: "no soy una url"` | `expected a URL` |
| entry with no `account_key` | `Missing option 'account_key' in projects` |
| `projects: []` | accepted |

That is the concrete argument for typing `url` rather than `str`, which the open item about
`account_manager_url` makes only in the abstract.

Then end to end: setting two projects and restarting attached both, and the account manager conflict
left the app in **`state: error`** — not the `stopped` that 3.8.4's caveat predicted.

## The upgrade path, measured

`projects` is required-with-a-default — posting options without it is rejected with
`Missing option 'projects' in root` — so the one risk here that no test covers is an existing 3.9.1
install, whose stored options have no such key, being updated in place.

Measured against a real Supervisor rather than assumed: 3.9.1 installed, given five options and
started, then updated with `ha apps update`.

```
version: 3.10.0   state: started
options: {"projects": [], "gui_rpc_password": "secreto", "max_ncpus": 75.0,
          "start_hour": "22:00", "end_hour": "07:00", "remote_hosts": ["192.168.1.50"]}
```

Every option preserved, `projects: []` filled in from the schema default. Supervisor merges the
defaults *under* the persisted options rather than validating the persisted options against the new
schema, so existing installs are unaffected.

## What this was never tested against

Worth stating plainly, because the evidence above reads as more complete than it is: **no project
here was ever attached to a real BOINC project.** Every run used `http://example.invalid/...` with
invented account keys. That proves the operator issues the right calls and that the client persists
them; it says nothing about a real project accepting a key and sending work.

Two claims ride on exactly that, and neither is measured:

- **Whether an account key in this option authenticates.** A rejected key still leaves the project
  attached, so the failure is quiet — the client logs `Invalid or missing account key` and the app
  looks healthy.
- **`detach_when_done` draining real work**, which is the promise `DOCS.md` makes in so many words.
  The test projects had zero tasks, so it is asserted from BOINC's semantics, not observed.

Neither is a defect found and neither blocks merging. The procedure to close it is recorded in
`TODO.md`, including the one check that distinguishes an accepted key from a rejected one.

## Also here: two tooling commits

Verifying the above under Supervisor cost enough manual intervention to be worth fixing in place,
so `.claude/skills/run-boinc-addons/` carries three fixes. `up` treated an existing-but-stopped
container as running (`docker inspect` succeeds for a stopped one) and died on the first
`docker exec`; after an unclean stop `supervisor_run` gives up on a stale `/var/run/docker.pid`,
so `up` now clears it and starts `dockerd` itself; and `install` no longer refuses to run twice,
which is also the only way to make Supervisor re-read `config.yaml` and `translations/`, since it
snapshots them into `apps.json` at install time.

Verified by reproducing the broken state — stopping the container and running `up` once, which now
recovers unattended — and `shellcheck -s bash` is clean. `TODO.md` had the reinstall one written
down already, and it is closed.

Nothing outside `boinc/` and the skill changes, and neither triggers a build or a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka
