### PR TITLE
feat(boincui): lay the machines out in columns on a large screen

### DIFF
--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.0
+
+On a computer screen your machines now sit side by side, up to three across, instead of in one narrow column with empty space either side of it. Several machines fit without scrolling
+
+On a phone nothing changes: one machine after another, top to bottom. The page decides for itself how many fit, so a tablet gets two and a wide monitor three
+
+A task's progress bar and the percentage beside it no longer split across two lines when the space is tight
+
 ## 1.0.0
 
 The three old settings for a single BOINC client — address, port and password — are gone. If you are still using them instead of the BOINC clients list, this update leaves the app with no machines configured and the page will tell you so; add them to the list and it works again. If you already use the list, nothing changes

--- a/boincui/DEVELOPMENT.md
+++ b/boincui/DEVELOPMENT.md
@@ -144,6 +144,18 @@ gets one column because only one fits, not because a breakpoint said so. Measure
 | 1920px | 3 | 506px | 953px |
 | 2560px | 3 | 517px | 953px |
 
+**Those are viewport widths, and through ingress the viewport is not the monitor.** Home Assistant
+renders this app in an iframe beside its own sidebar — 256px expanded, 56px collapsed, hidden
+entirely on a narrow screen — so a 1920px monitor gives the page **1664px** and the column count
+drops a step earlier than the table suggests. That costs nothing here precisely because there are no
+breakpoints: the rule reads whatever width the iframe has. A layout tuned to monitor sizes would have
+been wrong by a sidebar. Measured at the real panel widths: 1664px → 3 columns, 1184px → 2, 1024px →
+2, 768px (a 1024px screen with the sidebar out) → 1, which is what that case already got.
+
+At 1664px the page fills the panel exactly, with no margin either side: `max-width: 102rem` is a
+content-box width, so the body totals 104rem with its padding — 1664px. Coincidence, but a
+convenient one, and a reason not to switch this file to `border-box` without re-measuring.
+
 Three pieces of that declaration are load-bearing and each was got wrong first:
 
 - **`min(24rem, 100%)`, not `24rem`.** Below 24rem a bare minimum overflows the viewport instead of

--- a/boincui/DEVELOPMENT.md
+++ b/boincui/DEVELOPMENT.md
@@ -118,6 +118,101 @@ distinguish this app from `boinctui` and from the HACS integration; what disting
 that it is graphical and usable from a phone. That is a legitimate answer, just not the one that was
 originally planned — worth knowing before someone re-adds the aggregate view expecting it to be new.
 
+## The page is mobile first and grows into a desktop, with no breakpoint anywhere
+
+One section per machine reads well on a phone and wasted a desktop: at 1920px the old `max-width:
+48rem` used **768 of 1920 pixels — 40%** — and four machines made the page **1848px tall**, so the
+fourth was below the fold on a monitor with room for all four at once. Widening the column alone
+would have bought almost nothing, because a machine's own content is already capped well below it
+(`.modes` at 27rem, `progress` at 8rem); the column would just have stretched the task table.
+
+So the machines are a grid, and the whole of it is this:
+
+```css
+grid-template-columns: repeat(auto-fill, minmax(min(24rem, 100%), 1fr));
+```
+
+There is **no media query in this file, and there should not be one**. `auto-fill` lays down as many
+24rem columns as fit and never makes one narrower, which is the same rule at every size — a phone
+gets one column because only one fits, not because a breakpoint said so. Measured:
+
+| viewport | columns | column width | page height |
+|---|---|---|---|
+| 390px | 1 | 358px | 2028px |
+| 768px | 1 | 736px | 1788px |
+| 1024px | 2 | 476px | 1212px |
+| 1920px | 3 | 506px | 953px |
+| 2560px | 3 | 517px | 953px |
+
+Three pieces of that declaration are load-bearing and each was got wrong first:
+
+- **`min(24rem, 100%)`, not `24rem`.** Below 24rem a bare minimum overflows the viewport instead of
+  collapsing to one column, and the page scrolls sideways on a small phone.
+- **`auto-fill`, not `auto-fit`.** `auto-fit` collapses the empty tracks, so a single machine stretches
+  across the whole page — a three-column task table 1500px wide. `auto-fill` keeps the tracks and the
+  lone machine stays one column, left-aligned.
+- **`1fr` as the maximum, not a fixed width.** A fixed 32rem maximum left a column *narrower than the
+  page used to be* whenever only one fits, which is a tablet held upright: 512px where it had been
+  736px. What stops a fourth column appearing is the body's own `max-width: 102rem`, which has room
+  for exactly three — a fourth would need 105.5rem.
+
+Past three the eye has to travel across an ultrawide monitor to compare two machines, which is the
+thing this layout exists to make easy.
+
+### A lone machine keeps the width it had
+
+`.machines:has(> .machine:only-child)` gives a single machine a 48rem track, exactly the old page
+width. Without it the commonest setup of all — one Home Assistant, one BOINC client running on it —
+would come out of a change meant to use more space **narrower than it went in**, at one column of a
+three-column grid. In a browser too old for `:has()` that is what happens, which is a worse page but
+not a broken one.
+
+It also means the wrapper must contain machines and nothing else: one machine plus one stray element
+stops being an only child and the page silently widens. `test_app.py` asserts the wrapper's children,
+because nothing about that is visible in the stylesheet.
+
+### The stacked activity buttons are untouched, and the reason still holds
+
+The obvious follow-on — lay the three modes across the row now that there is width — does not apply:
+a column is about 30rem, no wider than the single column the stacking decision was made for. Three
+labels with their descriptions still do not fit across one. The argument above about phones is
+unchanged, not overridden.
+
+### What it costs
+
+Grid rows are as tall as their tallest machine, so a short machine in the last row leaves the rest of
+that row empty. Masonry would fix it and is not portable enough to rely on. Accepted: the alternative
+is measuring heights in JavaScript, in an app that deliberately ships none.
+
+## The progress bar gives up width before the percentage moves
+
+They are one reading, so they stay on one line, and `.bar` is a flex row that shrinks the bar down to
+2rem before anything wraps. A bar can lose most of its length and still say roughly how far along a
+task is; a percentage pushed onto the next line reads as belonging to the row below it.
+
+`white-space: nowrap` was tried first and is wrong twice over. It gives the cell a minimum the table
+cannot honour on a phone, so at 390px the columns **overlapped** — *"42%in 2 days"*. Making the bar
+shrinkable instead fixed the overlap and then made the whole page scroll sideways, because the table's
+own minimum width still exceeded the viewport. `flex-wrap: wrap` is what settles it: one line whenever
+there is room, and the old two-line fallback when there genuinely is not.
+
+Narrow columns are why this surfaced now — it was already possible in one wide column, and the first
+machine in a four-machine screenshot was already doing it.
+
+So a phone still shows the percentage under its bar, exactly as before, and a wide enough column
+shows it beside. Shrinking the flex basis to 6rem to win the phone case as well was tried and
+reverted: flex wraps a line before it shrinks an item, so it only moved which widths were affected.
+
+**`.pct` has a `min-width` wide enough for `100%`, and that is what stops the table looking ragged.**
+Left to size themselves, `8%` fits beside its bar at a column width where `42%` does not, so rows in
+the *same table* disagreed — measured at 1440px, where three of five bars wrapped and the other two
+did not. A fixed width makes every row need the same space, so they all wrap or none do. Tables still
+differ from each other, which is fine: they are different machines with different project names.
+
+Two declarations look redundant and are not. `max-width` alongside the flex basis: without it the bar
+contributes its full 8rem to the table's minimum width and the page scrolls sideways on a phone.
+`min-width: 2rem`: it is the floor the bar shrinks to before the line gives up and wraps.
+
 ## Only running tasks are listed
 
 `get_results()` returns every task. A machine with a normal work buffer has dozens, which is

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "1.0.0"
+version: "1.1.0"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"

--- a/boincui/server/templates/index.html
+++ b/boincui/server/templates/index.html
@@ -13,14 +13,40 @@
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     line-height: 1.5;
     margin: 0 auto;
-    max-width: 48rem;
+    /* Three machine columns at their widest, and no more: past that the eye has to travel across an
+       ultrawide monitor to compare two machines, which is the thing this layout is for. */
+    max-width: 102rem;
     padding: 1.5rem 1rem;
   }
   h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
   .muted { opacity: 0.7; font-size: 0.9rem; }
+  /* Prose does not get the full width even when there is one: a line of text spanning 102rem is
+     unreadable regardless of how large the screen is. */
+  .intro, .card { max-width: 48rem; }
+  /* One column on a phone, more as the window allows, decided without a single breakpoint: auto-fill
+     lays down as many 24rem columns as fit and never makes one narrower than that. `min(24rem, 100%)`
+     is what keeps it honest below 24rem, where a bare 24rem minimum would overflow a small phone
+     instead of collapsing to one column.
+     auto-fill rather than auto-fit on purpose -- auto-fit collapses the empty tracks, which would
+     stretch a lone machine across the whole page.
+     `1fr` as the maximum, not a fixed width: a fixed one leaves a column narrower than the page used
+     to be whenever only one of them fits, which is a tablet held upright. What stops a fourth column
+     appearing is the body's own max-width, which has room for exactly three of these. */
+  .machines {
+    align-items: start;
+    display: grid;
+    gap: 1.75rem 2.5rem;
+    grid-template-columns: repeat(auto-fill, minmax(min(24rem, 100%), 1fr));
+    margin: 1.75rem 0;
+  }
+  /* One machine keeps the width the page had before there was a grid. Otherwise the commonest setup
+     of all -- one Home Assistant, one BOINC client on it -- would come out of this change narrower
+     than it went in. */
+  .machines:has(> .machine:only-child) {
+    grid-template-columns: minmax(min(24rem, 100%), 48rem);
+  }
   .machine {
     border-left: 3px solid currentColor;
-    margin: 1.75rem 0;
     padding-left: 0.9rem;
   }
   .machine.problem { opacity: 0.85; }
@@ -37,8 +63,21 @@
   th, td { text-align: left; padding: 0.3rem 0.6rem 0.3rem 0; vertical-align: baseline; }
   th { font-weight: 600; border-bottom: 1px solid currentColor; font-size: 0.85rem; }
   td.due { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
-  progress { width: 100%; max-width: 8rem; vertical-align: middle; }
-  .pct { font-variant-numeric: tabular-nums; font-size: 0.9rem; }
+  /* The bar and its percentage are one reading, so they stay on one line and the bar gives up width
+     first -- it can lose most of its length and still say roughly how far along the task is, while a
+     percentage pushed onto a second line reads as belonging to the row below.
+     A flex row rather than `white-space: nowrap`: nowrap gives the cell a minimum the table cannot
+     honour on a phone, and the columns then overlap instead of narrowing. It still wraps when there
+     is genuinely no room -- without that the table's minimum width alone made the page scroll
+     sideways on a phone, which is a worse fault than the one being fixed. */
+  .bar { align-items: center; display: flex; flex-wrap: wrap; gap: 0.4rem; }
+  /* max-width as well as the flex basis, redundant as it looks: without it the bar contributes its
+     full 8rem to the table's minimum width and the page scrolls sideways on a phone. */
+  progress { flex: 1 1 8rem; min-width: 2rem; max-width: 8rem; }
+  /* Wide enough for "100%", so every row in a table needs the same width and they all wrap together
+     or not at all. Left to size itself, "8%" fits beside its bar on a column width where "42%" does
+     not, and the table comes out ragged. */
+  .pct { flex: none; font-variant-numeric: tabular-nums; font-size: 0.9rem; min-width: 2.4rem; }
   button {
     border: 1px solid currentColor;
     border-radius: 0.375rem;
@@ -90,7 +129,7 @@
 </head>
 <body>
 <h1>BOINC UI</h1>
-<p class="muted">Shows what your BOINC clients are doing, and lets you start and stop their
+<p class="muted intro">Shows what your BOINC clients are doing, and lets you start and stop their
 computing.</p>
 
 {% if machines is none %}
@@ -110,6 +149,10 @@ computing.</p>
 </div>
 
 {% else %}
+<!-- One wrapper around every machine, with nothing else inside it: the layout is a grid over these
+     children, and the single-machine rule reads `.machine:only-child`. Putting anything else in here
+     would silently widen a page that has one machine and one stray element. -->
+<div class="machines">
   {% for machine in machines %}
   <div class="machine{% if machine.error %} problem{% endif %}">
     <h2>{{ machine.name }}</h2>
@@ -172,8 +215,10 @@ computing.</p>
           <td>{{ task.project }}</td>
           <td>
             {% if task.fraction_done is not none %}
-            <progress value="{{ task.fraction_done }}" max="1"></progress>
-            <span class="pct">{{ '%.0f' | format(task.fraction_done * 100) }}%</span>
+            <span class="bar">
+              <progress value="{{ task.fraction_done }}" max="1"></progress>
+              <span class="pct">{{ '%.0f' | format(task.fraction_done * 100) }}%</span>
+            </span>
             {% else %}—{% endif %}
           </td>
           <td class="due">{{ task.deadline | due }}</td>
@@ -197,6 +242,7 @@ computing.</p>
     {% endif %}
   </div>
   {% endfor %}
+</div>
 {% endif %}
 
 <form method="post" action="refresh">

--- a/boincui/server/test/test_app.py
+++ b/boincui/server/test/test_app.py
@@ -83,6 +83,46 @@ def modes_in(page):
     return collector.buttons
 
 
+# Elements that never get a closing tag, so counting depth has to skip them or it only ever goes up.
+VOID_ELEMENTS = frozenset(('area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+                           'link', 'meta', 'param', 'source', 'track', 'wbr'))
+
+
+class GridChildCollector(HTMLParser):
+    """The classes of the direct children of the machine grid, in order."""
+
+    def __init__(self):
+        super().__init__()
+        self.children = []
+        self._depth = None
+
+    def handle_starttag(self, tag, attrs):
+        classes = dict(attrs).get('class', '')
+        if self._depth is None:
+            if 'machines' in classes.split():
+                self._depth = 0
+            return
+        if tag in VOID_ELEMENTS:
+            return
+        if self._depth == 0:
+            self.children.append(classes)
+        self._depth += 1
+
+    def handle_endtag(self, tag):
+        if self._depth is None or tag in VOID_ELEMENTS:
+            return
+        self._depth -= 1
+        # Back past the wrapper's own closing tag: anything after it is not part of the grid.
+        if self._depth < 0:
+            self._depth = None
+
+
+def grid_children_in(page):
+    collector = GridChildCollector()
+    collector.feed(page)
+    return collector.children
+
+
 def client_for(snapshot, clients=None):
     app = create_app(snapshot)
     app.config.update(TESTING=True, CLIENTS=clients if clients is not None else [])
@@ -157,6 +197,37 @@ class TestStates(unittest.TestCase):
         page = self.page_for(snapshot_of(machine(name='first'), machine(name='second')))
 
         self.assertLess(page.index('first'), page.index('second'))
+
+
+class TestMachineGrid(unittest.TestCase):
+    """The structure the layout is built on.
+
+    The machines are laid out as a grid over the children of one wrapper, and the rule that keeps a
+    lone machine at the width the page had before the grid existed reads `.machine:only-child`. Both
+    are invisible in the stylesheet if something else is ever rendered inside that wrapper: a single
+    machine plus one stray element stops being an only child, and the page silently widens.
+    """
+
+    def page_for(self, snapshot):
+        return client_for(snapshot).get('/').get_data(as_text=True)
+
+    def test_should_hold_nothing_but_machines(self):
+        page = self.page_for(snapshot_of(
+            machine(name='first', running=[task()]),
+            machine(name='second', error='boom', error_kind='cannot_connect'),
+        ))
+
+        self.assertEqual(grid_children_in(page), ['machine', 'machine problem'])
+
+    def test_should_leave_a_single_machine_as_the_only_child(self):
+        page = self.page_for(snapshot_of(machine(name='alone')))
+
+        self.assertEqual(len(grid_children_in(page)), 1)
+
+    def test_should_have_one_grid_for_the_stylesheet_to_find(self):
+        page = self.page_for(snapshot_of(machine(name='first'), machine(name='second')))
+
+        self.assertEqual(page.count('class="machines"'), 1)
 
 
 class TestFormatDue(unittest.TestCase):


### PR DESCRIPTION
Adapts the page to a large screen without giving up the phone. Releases `boincui` **1.1.0**.

## The problem, measured

At 1920px the page used **768 of 1920 pixels — 40%** — and four machines made it **1848px tall**, so
the fourth was below the fold on a monitor with room for all four side by side.

Widening the column alone would have bought almost nothing: a machine's own content is already capped
well below it (`.modes` at 27rem, `progress` at 8rem), so the extra width would have gone to
stretching the task table.

## The change

The machines are a grid, and that is essentially the whole of it:

```css
grid-template-columns: repeat(auto-fill, minmax(min(24rem, 100%), 1fr));
```

**There is no media query anywhere in this change.** A phone gets one column because only one fits,
not because a breakpoint said so — the same rule at every size:

| viewport | columns | column width | page height |
|---|---|---|---|
| 390px | 1 | 358px | 2028px |
| 768px | 1 | 736px | 1788px |
| 1024px | 2 | 476px | 1212px |
| 1920px | 3 | 506px | **953px** (was 1848px) |
| 2560px | 3 | 517px | 953px |

Three parts of that declaration are load-bearing, and each was got wrong first and caught by
measuring rather than by looking:

- **`min(24rem, 100%)`, not `24rem`** — a bare minimum overflows below 24rem, and the page scrolls
  sideways on a small phone.
- **`auto-fill`, not `auto-fit`** — `auto-fit` collapses the empty tracks, so one machine stretches
  across the page and gets a 1500px-wide three-column table.
- **`1fr` as the maximum, not a fixed width** — a fixed 32rem left a column *narrower than the page
  used to be* whenever only one fits, i.e. a tablet held upright: 512px where it had been 736px.

What limits it to three columns is the body's own `max-width: 102rem`; a fourth would need 105.5rem.
Past three, comparing two machines means travelling across an ultrawide monitor, which is the thing
the layout is for.

### A lone machine keeps the width it had

`.machines:has(> .machine:only-child)` gives a single machine a 48rem track — exactly the old page.
Without it the commonest setup of all, one Home Assistant with one BOINC client on it, would come out
of a change meant to *use more space* narrower than it went in. A browser too old for `:has()` gets
one column of three, which is worse but not broken.

It also means the wrapper must hold machines and nothing else: one machine plus one stray element
stops being an only child and the page silently widens. `test_app.py` asserts that, because nothing
about it is visible in the stylesheet.

### The stacked activity buttons are untouched

The obvious follow-on — lay the three modes across the row now there is width — does not apply: a
column is about 30rem, no wider than the single column that decision was made for. The existing
argument in `DEVELOPMENT.md` is unchanged, not overridden.

## The progress bar, which narrower columns exposed

The bar and its percentage are one reading and now stay on one line, as a flex row that shrinks the
bar first. Two false starts, both worth recording:

- **`white-space: nowrap` is wrong twice.** It gives the cell a minimum the table cannot honour, so at
  390px the columns *overlapped* — `42%in 2 days`. Making the bar shrinkable fixed the overlap and
  then made the whole page scroll sideways, because the table's minimum still exceeded the viewport.
  `flex-wrap: wrap` settles it: one line where there is room, the old two-line fallback where there
  is not.
- **`.pct` needed a fixed width.** Left to size themselves, `8%` fits beside its bar at a column width
  where `42%` does not — at 1440px three of five bars wrapped and two did not, in the same table.
  Now every row needs the same space, so they agree.

## Verification

- 65 unit tests pass, both locally and in the shipped Debian Python via the built image.
- `smoke.sh boincui` passes, including the ingress guard that every emitted URL stays relative.
- Layout measured in a real browser at 390 / 768 / 1024 / 1440 / 1920 / 2560, four machines and one:
  **no horizontal overflow at any width**, and the column counts above.
- Rendering was driven against fabricated machines, so no BOINC client was involved and every page
  state was reachable.

`DOCS.md` and `README.md` say nothing about layout, so neither changed. The reasoning and the
measurements are in `boincui/DEVELOPMENT.md`, as `CLAUDE.md` requires for UI decisions.
