### PR TITLE
feat(boincui): say which processor each machine runs on

### DIFF
--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+
+Each machine now shows the processor it runs on and how many cores it has, under its name — useful when you have several and their names do not say what they are
+
+That is how many cores the computer has, not how many BOINC is allowed to use, so a machine limited to part of its processor runs fewer tasks than it has cores. A machine that does not report its processor is shown exactly as before
+
 ## 1.1.0
 
 On a computer screen your machines now sit side by side, up to three across, instead of in one narrow column with empty space either side of it. Several machines fit without scrolling

--- a/boincui/DEVELOPMENT.md
+++ b/boincui/DEVELOPMENT.md
@@ -225,6 +225,67 @@ Two declarations look redundant and are not. `max-width` alongside the flex basi
 contributes its full 8rem to the table's minimum width and the page scrolls sideways on a phone.
 `min-width: 2rem`: it is the floor the bar shrinks to before the line gives up and wraps.
 
+## A machine says which processor it is, and nothing else about its hardware
+
+The name of a machine is whatever its owner typed — *attic pc* says nothing about what it is. One
+line under it, from `get_host_info`, does: the processor and its core count. It also explains the
+numbers below it, since the running tasks are normally one per core.
+
+**Everything else `host_info` offers was left out on purpose.** Memory, disk, OS version, GPUs and
+the benchmark figures are a hardware sheet, and BOINC Manager already has a whole *Computer info*
+panel for that. This page is read at a glance; a second machine has to fit on the screen beside the
+first one.
+
+**There is no live processor usage in this RPC, and no amount of design gets one.** `host_info` is a
+static description plus stored benchmark results — GUI RPC exposes no utilisation percentage at all.
+The nearest honest answer is the running-task count the page already shows.
+
+**The core count is the computer's, not BOINC's allowance.** A client held to half the processor by
+`max_ncpus` still reports every core here, so a machine can legitimately say *14 cores* with four
+tasks running. Making the two agree would mean reporting a different number than every other BOINC
+tool shows for that machine.
+
+### BOINC's CPUID decoding is stripped, and the vendor is what saves the line
+
+`get_processor_info` (`lib/hostinfo.cpp`) appends its own reading of the CPUID to the model:
+
+```
+Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz [Family 6 Model 158 Stepping 10]
+```
+
+That bracket roughly doubles the length of the line and means nothing to the reader, so it goes.
+
+What makes the fallback to `p_vendor` load-bearing rather than defensive is that **on some machines
+the model is nothing but the bracket**. Verified against a real client on Apple Silicon:
+
+```
+#CPUS: 14
+CPU vendor: ARM
+CPU model: [Impl 0x61 Arch 8 Variant 0x0 Part 0x000 Rev 0]
+```
+
+Stripping without falling back would have left that machine with no processor at all. It now reads
+*ARM · 14 cores*. The vendor is a fallback and not a second part of the line because on a machine
+that does name its processor the model already opens with the readable form of the vendor — *Intel(R)
+Core(TM)* — and `GenuineIntel` in front of it is noise.
+
+### The core count is joined by a non-breaking space
+
+A full Intel model name plus the count does not fit one column on a phone, and measured at 390px it
+broke in the worst possible place — *Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz · 12* / *cores*. A
+non-breaking space inside `12 cores` moves the only available break to the separator, so the second
+line reads *12 cores* whole. The line still wraps; it now wraps somewhere that reads.
+
+### It is read in the poll, and left out when it is missing
+
+`get_host_info` is a fourth call in `_read_state`, not a one-off at startup. Two things follow: a
+machine that was switched off when the app started describes itself as soon as it answers, and an
+activity change keeps its processor line, because an action re-reads state through the same function.
+
+A client that says nothing usable — or answers this request with `<unauthorized/>`, which the library
+turns into `True` rather than a dict — gets no line rather than a heading with nothing under it. It
+is not an error worth a message on a status page.
+
 ## Only running tasks are listed
 
 `get_results()` returns every task. A machine with a normal work buffer has dozens, which is

--- a/boincui/DOCS.md
+++ b/boincui/DOCS.md
@@ -42,6 +42,12 @@ app's. If it refuses the connection, that is the address to put in its list of a
 Each machine gets its own section, showing whether it is computing and, when it is not, why — being
 outside its allowed hours and the processor being busy are the usual reasons.
 
+Under the name is the processor that machine runs on and how many cores it has, which is handy when
+several machines are listed and their names do not say what they are. That is the number of cores the
+computer has, not how many BOINC is allowed to use, so a machine limited to part of its processor
+runs fewer tasks than it has cores. A machine that does not report its processor simply has no such
+line.
+
 The table lists only the tasks running at that moment, which is normally one per processor core. A
 line above it counts the rest: **waiting** are downloaded and queued, **finished** are done and
 waiting to be sent back. To see the full queue, use the **boinctui** app.

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "1.1.0"
+version: "1.2.0"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"

--- a/boincui/server/boinc.py
+++ b/boincui/server/boinc.py
@@ -9,7 +9,7 @@ import logging
 
 from pyboinc import init_rpc_client
 from pyboinc.rpc_client import Mode
-from status import describe_activity, describe_mode
+from status import describe_activity, describe_mode, describe_processor
 
 DEFAULT_PORT = 31416
 # BOINC's own client gives up well before this; the point is only that a host which accepts the
@@ -154,11 +154,16 @@ async def _authenticate(client, host: str, port: int) -> None:
 
 async def _read_state(client) -> dict:
     cc_status = await client.get_cc_status()
+    # The processor is read here rather than once per machine at startup, so that a machine which
+    # was switched off when the app started still describes itself as soon as it answers. It is also
+    # why acting on a machine keeps its processor line: an action re-reads the state through here.
+    host_info = await client.get_host_info()
     projects = _as_list(await client.get_project_status())
     results = _as_list(await client.get_results())
     return {
         'activity': describe_activity(cc_status),
         'mode': describe_mode(cc_status),
+        'processor': describe_processor(host_info),
         **_summarise(results, projects),
     }
 

--- a/boincui/server/status.py
+++ b/boincui/server/status.py
@@ -5,6 +5,8 @@ The tables come from the client's own source so the wording matches what BOINC s
 `lib/common_defs.h`.
 """
 
+import re
+
 # BOINC looks these up with an exact `switch`, not bit tests, and that is deliberate: the values
 # look like flags up to 4096, but 4097 onwards are sequential and would collide with combinations
 # (4097 == 4096 | 1). Matching on the exact value is the only correct reading.
@@ -51,6 +53,11 @@ MODE_KEYS = {
     RUN_MODE_NEVER: 'never',
 }
 
+# BOINC appends its own decoding of the CPUID to the model string -- e.g. "Intel(R) Core(TM) i7-8700
+# CPU @ 3.20GHz [Family 6 Model 158 Stepping 10]" (`get_processor_info`, lib/hostinfo.cpp). It
+# roughly doubles the length of the line and says nothing to someone glancing at a status page.
+_CPUID_SUFFIX = re.compile(r'\s*\[[^]]*]\s*$')
+
 
 def describe_activity(cc_status: dict | None) -> str:
     """One line saying whether the client is computing, and if not, why not.
@@ -69,6 +76,43 @@ def describe_activity(cc_status: dict | None) -> str:
         # suspend reason, which it does on its own cycle rather than when the mode is set.
         return 'Paused — someone asked it to stop'
     return 'Computing'
+
+
+def describe_processor(host_info) -> str | None:
+    """The machine's processor in one line, e.g. "ARM · 14 cores".
+
+    Returns None when the client described nothing usable, so the page can leave the line out
+    instead of printing a heading with no information under it.
+
+    `host_info` is whatever the library made of the reply, which is not always a dict: a
+    self-closing tag becomes `True` and an empty one a bare string. A client that will not answer
+    this request is not an error worth reporting on a status page, so it takes the same path as one
+    that answers without saying anything.
+    """
+    if not isinstance(host_info, dict):
+        return None
+
+    model = _CPUID_SUFFIX.sub('', str(host_info.get('p_model') or '')).strip()
+    # The vendor is a fallback rather than a second part of the line: it holds the CPUID string
+    # ("GenuineIntel", "AuthenticAMD", "ARM"), and a model already begins with the readable form of
+    # it. It is needed because on some machines the model is nothing *but* the decoding stripped
+    # above -- an Apple Silicon host reports "[Impl 0x61 Arch 8 Variant 0x0 Part 0x000 Rev 0]" and
+    # no name at all, verified against a real client -- which leaves the vendor as the only readable
+    # thing on offer.
+    if not model:
+        model = str(host_info.get('p_vendor') or '').strip()
+    parts = [model] if model else []
+
+    cores = host_info.get('p_ncpus')
+    # `True` is what the library makes of a self-closing tag, and it counts as an int here: without
+    # excluding it, a client that sends `<p_ncpus/>` would be reported as having one core.
+    if isinstance(cores, int) and not isinstance(cores, bool) and cores > 0:
+        # A non-breaking space, because a long model name wraps this line on a phone and the count is
+        # where it broke: "Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz · 12" / "cores". The line may
+        # still wrap, now only at the separator, which leaves the count whole on the second line.
+        parts.append(f'{cores}\N{NO-BREAK SPACE}core{"s" if cores > 1 else ""}')
+
+    return ' · '.join(parts) or None
 
 
 def describe_mode(cc_status: dict | None) -> str | None:

--- a/boincui/server/templates/index.html
+++ b/boincui/server/templates/index.html
@@ -51,6 +51,9 @@
   }
   .machine.problem { opacity: 0.85; }
   .machine h2 { font-size: 1.15rem; margin: 0; }
+  /* Part of the heading block rather than a paragraph of its own: it says which computer this is,
+     which is the same job the name above it does. */
+  .processor { margin: 0.1rem 0 0.35rem; }
   .status { margin: 0.15rem 0; }
   .counts { font-size: 0.9rem; opacity: 0.75; margin: 0.15rem 0 0.75rem; }
   .card {
@@ -182,6 +185,9 @@ computing.</p>
     <p class="status"><strong>Something went wrong.</strong> {{ machine.error }}</p>
 
     {% else %}
+    {% if machine.state.processor %}
+    <p class="muted processor">{{ machine.state.processor }}</p>
+    {% endif %}
     <p class="status">{{ machine.state.activity }}</p>
 
     <form method="post" action="mode" class="activity">

--- a/boincui/server/test/test_app.py
+++ b/boincui/server/test/test_app.py
@@ -19,7 +19,7 @@ URL_ATTRIBUTES = ('href', 'src', 'action', 'formaction')
 
 def machine(name='pc', error=None, error_kind=None, running=(), queued=0, ready=0,
             projects=(('Example Project', 'https://example.org/'),), activity='Computing',
-            mode='auto'):
+            mode='auto', processor=None):
     return {
         'name': name,
         'host': 'pc.local',
@@ -28,6 +28,7 @@ def machine(name='pc', error=None, error_kind=None, running=(), queued=0, ready=
         'state': None if error else {
             'activity': activity,
             'mode': mode,
+            'processor': processor,
             'running': list(running),
             'queued': queued,
             'ready_to_report': ready,
@@ -171,6 +172,20 @@ class TestStates(unittest.TestCase):
         page = self.page_for(snapshot_of(machine(activity='Paused — the processor is busy with something else')))
 
         self.assertIn('the processor is busy', page)
+
+    def test_should_show_the_processor_under_the_machines_name(self):
+        page = self.page_for(snapshot_of(machine(name='attic pc', processor='AMD Ryzen 5 · 12 cores')))
+
+        self.assertIn('AMD Ryzen 5 · 12 cores', page)
+        self.assertLess(page.index('attic pc'), page.index('AMD Ryzen 5'))
+
+    def test_should_leave_out_the_processor_line_when_the_machine_did_not_report_one(self):
+        # A client that will not describe its hardware still gets a complete machine section: the
+        # line is simply absent, rather than a heading with nothing under it.
+        page = self.page_for(snapshot_of(machine(processor=None)))
+
+        self.assertNotIn('class="muted processor"', page)
+        self.assertIn('Computing', page)
 
     def test_should_report_each_failure_kind_against_its_own_machine(self):
         for kind, expected in (

--- a/boincui/server/test/test_boinc.py
+++ b/boincui/server/test/test_boinc.py
@@ -57,6 +57,21 @@ NO_PROJECTS = '<boinc_gui_rpc_reply>\n<projects>\n</projects>\n</boinc_gui_rpc_r
 NO_TASKS = results_reply()
 
 
+def host_info_reply(*fields: str) -> str:
+    return ('<boinc_gui_rpc_reply>\n<host_info>\n' + '\n'.join(fields)
+            + '\n</host_info>\n</boinc_gui_rpc_reply>')
+
+
+# The model carries BOINC's own CPUID decoding, exactly as a real Linux client sends it.
+HOST_INFO = host_info_reply(
+    '<p_vendor>GenuineIntel</p_vendor>',
+    '<p_model>Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz [Family 6 Model 158 Stepping 10]</p_model>',
+    '<p_ncpus>12</p_ncpus>',
+)
+
+NO_HOST_INFO = host_info_reply()
+
+
 def cc_status(mode=2, suspend_reason=0, perm=None):
     return (f'<boinc_gui_rpc_reply>\n<cc_status>\n<task_mode>{mode}</task_mode>\n'
             f'<task_mode_perm>{mode if perm is None else perm}</task_mode_perm>\n'
@@ -71,11 +86,13 @@ class FakeBoincClient:
     and <auth2> is accepted only when it carries md5(nonce + password).
     """
 
-    def __init__(self, password=PASSWORD, tasks=None, projects=PROJECTS, status=None, rejects=False):
+    def __init__(self, password=PASSWORD, tasks=None, projects=PROJECTS, status=None,
+                 host_info=HOST_INFO, rejects=False):
         self.password = password
         self.tasks = tasks if tasks is not None else results_reply(running_task())
         self.projects = projects
         self.status = status if status is not None else cc_status()
+        self.host_info = host_info
         # A client that accepts the connection and then hangs up, which is what BOINC does to a
         # caller missing from its allowed list -- it checks the address only after accepting.
         self.rejects = rejects
@@ -146,6 +163,8 @@ class FakeBoincClient:
                     reply = f'<boinc_gui_rpc_reply>\n<{tag}/>\n</boinc_gui_rpc_reply>'
                 elif '<get_cc_status' in request:
                     reply = self.status
+                elif '<get_host_info' in request:
+                    reply = self.host_info
                 elif '<get_project_status' in request:
                     reply = self.projects
                 elif '<get_results' in request:
@@ -236,6 +255,41 @@ class TestSingleClient(unittest.TestCase):
 
         self.assertIn('Paused', state['activity'])
         self.assertIn('did not say why', state['activity'])
+
+    def test_should_describe_the_processor_without_boincs_cpuid_decoding(self):
+        with FakeBoincClient() as server:
+            state = self.read_one(server)['state']
+
+        self.assertEqual('Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz · 12\u00a0cores', state['processor'])
+
+    def test_should_fall_back_to_the_vendor_when_the_client_reports_no_model(self):
+        info = host_info_reply('<p_vendor>AuthenticAMD</p_vendor>', '<p_ncpus>1</p_ncpus>')
+        with FakeBoincClient(host_info=info) as server:
+            state = self.read_one(server)['state']
+
+        self.assertEqual('AuthenticAMD · 1\u00a0core', state['processor'])
+
+    def test_should_fall_back_to_the_vendor_when_the_model_is_only_a_cpuid(self):
+        # Not hypothetical: this is exactly what a real client on Apple Silicon reports, so stripping
+        # the decoding without falling back would leave the machine with no processor at all.
+        info = host_info_reply(
+            '<p_vendor>ARM</p_vendor>',
+            '<p_model>[Impl 0x61 Arch 8 Variant 0x0 Part 0x000 Rev 0]</p_model>',
+            '<p_ncpus>14</p_ncpus>',
+        )
+        with FakeBoincClient(host_info=info) as server:
+            state = self.read_one(server)['state']
+
+        self.assertEqual('ARM · 14\u00a0cores', state['processor'])
+
+    def test_should_leave_out_the_processor_when_the_client_does_not_describe_it(self):
+        # An empty reply comes back as the string "\n", not a dict, and is not an error: the page
+        # simply has no processor line to show.
+        with FakeBoincClient(host_info=NO_HOST_INFO) as server:
+            machine = self.read_one(server)
+
+        self.assertIsNone(machine['error'])
+        self.assertIsNone(machine['state']['processor'])
 
     def test_should_report_a_rejected_password_rather_than_empty_data(self):
         # The library does not check authorisation on its query methods, so without our explicit
@@ -363,6 +417,8 @@ class TestActivityMode(unittest.TestCase):
         self.assertEqual('machine', machine['name'])
         self.assertEqual(1, len(machine['state']['running']))
         self.assertEqual(['Example Project'], [p['name'] for p in machine['state']['projects']])
+        # Without this the processor line would vanish the moment someone pressed an activity button.
+        self.assertIn('i7-8700', machine['state']['processor'])
 
     def test_should_follow_the_permanent_mode_not_a_temporary_one(self):
         # A temporary mode set from BOINC Manager reverts on its own, so highlighting it would mark


### PR DESCRIPTION
Each machine now shows the processor it runs on and how many cores it has, under its name — `ARM · 14 cores`. The name of a machine is whatever its owner typed, so *attic pc* says nothing about what it is; this does, and it explains the numbers below it, since the running tasks are normally one per core.

`boincui` 1.1.0 → **1.2.0**.

## Scope

Everything else `host_info` offers is deliberately left out. Memory, disk, OS version, GPUs and the benchmark figures are a hardware sheet, and BOINC Manager already has a whole *Computer info* panel for that — this page is read at a glance, and a second machine has to fit on the screen beside the first.

**There is no live processor usage to show, and no design gets one.** GUI RPC exposes no utilisation percentage at all: `host_info` is a static description plus stored benchmark results. The nearest honest answer is the running-task count the page already shows.

The core count is the computer's, not BOINC's allowance — a client held to half the processor by `max_ncpus` still reports every core here, so a machine can legitimately say *14 cores* with four tasks running. Making the two agree would mean printing a different number than every other BOINC tool shows for that machine.

## Verified against a real client, and it changed the code

Driven against a real BOINC client rather than only the fake server, as `DEVELOPMENT.md` asks. Two findings:

- On Apple Silicon, `p_model` is **nothing but** BOINC's CPUID decoding — `[Impl 0x61 Arch 8 Variant 0x0 Part 0x000 Rev 0]`, no processor name at all. Stripping that bracket (it roughly doubles the line and means nothing to a reader) would have left the machine with no processor whatsoever. The fallback to `p_vendor` is therefore the real case, not a defensive one: it now reads `ARM · 14 cores`. There is a test with that exact reply.
- Measured at 390px, a full Intel name broke the line at the worst possible place — `… @ 3.20GHz · 12` / `cores`. A non-breaking space inside the count moves the only available break to the separator, so the second line reads `12 cores` whole.

Checked on screen at 1664px (three columns, the line reads as part of the heading block) and at 390px.

## How it is wired

`get_host_info` is a fourth call in `_read_state`, not a one-off at startup. A machine that was switched off when the app started describes itself as soon as it answers, and an activity change keeps its processor line, because an action re-reads state through the same function.

A client that says nothing usable — or answers this request with `<unauthorized/>`, which the library turns into `True` rather than a dict — gets no line rather than a heading with nothing under it. Not an error worth a message on a status page.

## Tests

71 tests green, and also green inside the built image on Python 3.13.5, the version that actually ships. New cases: model + core count with the CPUID decoding stripped, the vendor fallback for a client with no model, the vendor fallback for a model that *is* only a CPUID, a client that describes nothing, that the line survives a mode change, and that the page renders it under the name and omits it when absent.

## Docs

`DEVELOPMENT.md` carries the decision with its evidence, per the repo's rule for UI/UX choices. `DOCS.md` and `CHANGELOG.md` are the user-facing halves; `translations/` is untouched, since no option changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka