### PR TITLE
feat(boincui): add an AppArmor profile, watching before it enforces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,9 @@ editing files outside a changed add-on's directory does not trigger its pipeline
   comments, or the PR description. Never point a user at a file or command they can't reach from
   the Home Assistant UI, the File editor add-on, or Samba. When an option's behavior changes,
   update its text in `translations/` too.
+- **A `CHANGELOG.md` entry is one paragraph, four or five lines at most.** It is read in a dialog by
+  someone deciding whether to press Update, not by a reviewer, so it says what changes for them and
+  stops. Everything that explains, justifies or qualifies the change — measurements, trade-offs,
+  what was rejected — goes in the PR description, `TODO.md` or a code comment, all of which have
+  room and the right audience. If an entry needs a second paragraph to stay honest, that is a sign
+  the release itself is doing two things.

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Standing backlog for this repo: known gaps, platform conformance items, and feat
 review. Consult it before starting work — what you are about to investigate may already be written
 up here with file:line references — and update it as items are resolved or discarded.
 
-Last reviewed 2026-08-15. Everything in **Resolved** below has shipped or been deliberately
+Last reviewed 2026-08-16. Everything in **Resolved** below has shipped or been deliberately
 discarded; it is kept in condensed form so the same ground is not re-covered, not as work to do.
 
 ---
@@ -48,20 +48,31 @@ The bugs found in the 2026-08-08 review all shipped in `boinc` 3.8.0–3.9.0 —
 
 ## Security / permissions
 
-- [ ] **`apparmor: false` on all three add-ons, against an explicit documented recommendation.**
-  These add-ons disable AppArmor *and* request `host_pid`, `host_uts`, `docker_api` and `video`, so
-  they sit at the low end of the platform's 1–6 rating by construction. Ties to the dead
-  `boinc/apparmor.txt.disable` under Housekeeping: writing a real profile matching the actual
-  process tree fixes both at once. Realistically a large task, not a quick win — but it should be a
-  recorded decision rather than an unexamined default.
+- [ ] **`apparmor: false` on `boinc` and `boinctui`.** `boincui` now ships a real profile — watching
+  rather than enforcing for now, see Resolved — which leaves the two harder ones. Both were left alone deliberately, not forgotten:
+  each is a different problem from `boincui`, and neither is a quick win.
 
-  **What a profile can and cannot buy here, since it is not the usual case.** BOINC's whole purpose
-  is to download third-party binaries from projects and execute them out of `slots/`, so a profile
-  cannot meaningfully restrict *what runs* — it has to permit executing arbitrary downloaded code,
-  or the add-on does nothing. What it can still do is bound the *blast radius* of that code: keep it
-  out of `/config`, off the host paths `host_pid` exposes, and away from the Docker socket
-  `docker_api` grants. That is worth having, but it is a different claim from the one "AppArmor
-  enabled" usually implies, and the item should be judged on it rather than on the rating.
+  **`boinc`: the rating cannot move, so the profile has to be justified on blast radius alone.**
+  `rating_security` (`supervisor/apps/utils.py`) ends with `if app.access_docker_api or
+  app.with_full_access: rating = 1` — an assignment, not an adjustment, so it overrides everything
+  before it. This add-on requests `docker_api`, so it is pinned at 1/8 whether or not it has a
+  profile. Any argument for writing one here is about what the profile actually prevents, and the
+  number Home Assistant shows will not reward it.
+
+  **And what it prevents is unusually limited.** BOINC's whole purpose is to download third-party
+  binaries from projects and execute them out of `slots/`, so a profile cannot restrict *what runs*
+  — it has to permit executing arbitrary downloaded code, or the add-on does nothing. What it can
+  still do is bound that code's reach: keep it out of `/config`, off the host paths `host_pid`
+  exposes, and away from the Docker socket `docker_api` grants. Worth having, but a different claim
+  from the one "AppArmor enabled" usually implies.
+
+  Ties to the dead `boinc/apparmor.txt.disable` under Housekeeping — that file is template
+  boilerplate for an s6-overlay image this add-on is not, so it is a starting point for nothing.
+
+  **`boinctui` is confining an interactive shell**, which is why it is not simply the `boincui` job
+  again. `run.sh` launches `ttyd`, which spawns `bash` → `boinctui` per ingress session, so the set
+  of executables reachable is "whatever the user types". Its rating is 6 by the same arithmetic
+  `boincui` had (5, −1 for AppArmor, +2 for ingress) — derived from the formula above, not measured.
 
 ## Conformance with the official HA apps docs
 
@@ -274,6 +285,21 @@ The "build a graphical web UI" item that used to dominate this file was answered
 see Resolved for what was decided and why. What follows is what it did **not** settle, in rough order
 of cost.
 
+- [ ] **Switch `boincui`'s AppArmor profile from `complain` to enforcing.** 1.3.0 ships it watching
+  only, and its `CHANGELOG.md` promises a later version that switches it on, so this is a commitment
+  to a user rather than an idea. **The work is deleting `,complain` from the flags line** in
+  `boincui/apparmor.txt`; everything else is deciding when.
+
+  **The gate:** `ha host logs -t kernel | grep 'apparmor="ALLOWED"'` comes back with nothing naming
+  the profile, on a host that has been running the app normally for a while — ideally more than one,
+  since the point of releasing in `complain` was to get evidence from machines that are not this
+  repo's devcontainer. Every line it does return names an operation and an exact path, which is
+  directly the rule to add.
+
+  Until it flips, the app reports 8/8 while confining nothing — see the 1.3.0 entry in Resolved for
+  why that is, and why the changelog says so out loud. **The rating will not change when it flips**,
+  which is worth knowing so nobody reads the unchanged number as the release having done nothing.
+
 - [ ] **Localise `boincui`'s page.** Only `translations/*.yaml` is translated today, and that covers
   configuration fields, not the page itself. If it is ever done, the activity control's wording
   should come from BOINC's own catalogue rather than a third phrasing — `locale/es/BOINC-Manager.po`
@@ -374,6 +400,10 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
   `monitored_files` is a regex that can over-match (`app` would also match
   `boinc/apparmor.txt.disable`), so that example needs a different filename or the note needs
   rewording.
+  **There is now a second reason to delete it**, and it is no longer only cosmetic: while it exists,
+  `apparmor.txt` cannot be added to `monitored_files` without a profile-only change to `boincui`
+  dragging `boinc` into the release gate — see the `boincui` 1.3.0 entry in Resolved. Deleting the
+  file unblocks that one-word CI fix.
 - The Dockerfile labels item was **stale and is closed** — see *Confirmed correct* under
   Conformance. They already agree across all three add-ons.
 
@@ -711,6 +741,71 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     itself.
 
   Between them, the recovery that gotcha 6 in `SKILL.md` documents actually works unattended now.
+
+## Shipped in `boincui` 1.3.0
+
+- [x] **An AppArmor profile for `boincui`, taking it from 6/8 to 8/8** (measured on a running
+  Supervisor before and after: `rating` 6 → 8, `apparmor` `disable` → `profile`). This is the
+  tractable third of the three-add-on item still open above, and it was picked first for a reason:
+  `boincui` executes no downloaded code and has no shell in its path, so the profile can say
+  something strong instead of having to permit everything.
+  - **Enabling it is a deletion.** `ATTR_APPARMOR` defaults to true and Supervisor uses
+    `apparmor.txt` as the profile whenever the file is present, so `config.yaml` declares neither —
+    the add-on linter rejects redeclaring a default.
+  - **The profile's own name does not matter.** `install_apparmor` runs `adjust_profile(self.slug,
+    …)`, which rewrites the `^profile <name>` line to the slug before `validate_profile` compares
+    them; the stored copy reads `profile local_boincui`. Note `get_profile_name` rejects a file with
+    two lines matching `^profile `, so a nested sub-profile must stay indented.
+  - **Every rule was measured, not guessed.** A `strace -f -e trace=file,network` run of the real
+    image against a real BOINC client — startup, a rendered page, an activity change, a clean stop —
+    showed **exactly one `execve`** (the interpreter at startup), **not one file opened for
+    writing**, and three socket families: AF_INET stream, AF_INET dgram (DNS) and AF_UNIX stream
+    (asyncio's self-pipe socketpair). The trace file list is what the rules were written against.
+  - **`abstractions/base` covers more than expected**, which is why the profile is short:
+    `signal (receive) peer=unconfined` (so Docker's SIGTERM still reaches it and the clean shutdown
+    survives), `unix (create)` and `unix peer=(label=@{profile_name})` (asyncio), and
+    `/{usr/,}lib{,32,64}/** r` — which is the whole Python stdlib plus flask and waitress. It does
+    **not** grant any `network` rule; those come from `abstractions/nameservice`, which is also the
+    only reason DNS works. Both abstractions are safe to rely on: the profile is parsed by the
+    *host*, and the official `dnsmasq` add-on profile uses `nameservice`, so HA OS ships it.
+  - **`/` is stat'd by Python at startup and no abstraction grants it**, so the profile does. Found
+    by reading the trace, not by it failing — which is the point, since nothing here could fail.
+  - **Music Assistant's profile is an anti-example worth knowing about**: it declares `capability,`
+    and `file,`, which grant everything, so it earns the +1 rating while confining nothing. The
+    `dnsmasq` one is the honest idiom — permissive outer profile for the s6/bashio layer, real
+    confinement in a nested profile around the binary. `boincui` needs neither, because `python3` is
+    PID 1 and the outer profile *is* the confinement.
+  - **What is verified, and what is not.** Verified: the profile parses under a real
+    `apparmor_parser`; Supervisor reads, renames, validates, stores and registers it; the app starts
+    and works with it declared. **Not verified: that it confines anything.** The devcontainer reports
+    `unsupported: ["apparmor"]`, so `AppArmorControl.available` is false and `docker/app.py` launches
+    the container with `apparmor=unconfined` — confirmed on the running container's `SecurityOpt`.
+    Docker Desktop's VM has no AppArmor either, and no Linux VM tooling is installed on the dev
+    machine. **Enforcement is therefore exercised for the first time on a real HA OS host**, and the
+    strace evidence above is what stands in for a `complain`-mode run. If a user ever reports the app
+    failing to start after this, that is the first place to look.
+  - **1.3.0 ships in `complain` mode and enforces nothing — a deliberate decision, taken knowing the
+    cost.** In that mode AppArmor blocks nothing and logs every access that would have been blocked,
+    so the rules meet a real kernel for the first time on users' hosts instead of on one developer
+    machine, and a rule missing from the profile costs a log line rather than an app that will not
+    start. Given that enforcement could not be tested at all locally (see above), that buys far
+    broader evidence than any pre-release pass on a single host would have.
+    **The cost, measured rather than assumed:** installed in the devcontainer with `complain` set,
+    Supervisor still reported **`rating: 8`** and `apparmor: profile`, because the `apparmor` property
+    (`apps/model.py`) only asks whether a profile of that name is registered and never looks at its
+    mode. So this release shows the maximum security rating while confining nothing — structurally
+    the same gap as the Music Assistant profile above, and the `CHANGELOG.md` entry says so in plain
+    words rather than letting the shield speak for itself. The flag survives `adjust_profile`, which
+    rewrites only the profile name.
+    Also worth knowing for the local-testing route, which still works: copy `boincui/` to the
+    `addons` share and **comment out `image:`**, or Supervisor pulls the published image and 404s on
+    an unreleased version (gotcha 4 in `SKILL.md`).
+  - **`apparmor.txt` is deliberately absent from CI's `monitored_files`**, so a change to the profile
+    alone triggers no build or version check. The pattern list is matched as an *unanchored bash
+    regex* against the whole changed-file string, so adding `apparmor.txt` would also match
+    `boinc/apparmor.txt.disable` and demand a `boinc` version bump on release — the exact over-match
+    CLAUDE.md warns about. There is no anchor that fixes it (`$` matches the end of the entire
+    string, not of one path). Add it once that dead file is deleted; see Housekeeping.
 
 ## Shipped as `boincui`, 0.1.0 → 1.0.0
 

--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ## 1.3.0
 
-BOINC UI now comes with a security profile: a list of the only things the app should ever need to do, which is read its own settings and talk to the BOINC machines you listed
-
-In this version the profile only watches. It records anything the app does beyond that list without stopping it, so that the list can be proved right on real installations before it starts being enforced. A later version will switch it on, and that is when it will actually stop the app doing anything else
-
-So nothing changes in how the app works, and nothing can break because of this. Note that the security rating on the app's Info page already goes from 6 to 8 out of 8, which is Home Assistant counting the profile as soon as it exists — it runs ahead of the protection itself until the version that switches it on
+BOINC UI now comes with a security profile: the list of the only things it should ever need to do, which is read its own settings and talk to the machines you listed. For now the profile only watches and stops nothing, so the list can be proved right on real installations before a later version switches it on. The security rating on the Info page goes from 6 to 8 out of 8 as soon as the profile exists, so it runs ahead of the protection itself until then. Nothing changes in how the app works
 
 ## 1.2.0
 

--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+
+BOINC UI now comes with a security profile: a list of the only things the app should ever need to do, which is read its own settings and talk to the BOINC machines you listed
+
+In this version the profile only watches. It records anything the app does beyond that list without stopping it, so that the list can be proved right on real installations before it starts being enforced. A later version will switch it on, and that is when it will actually stop the app doing anything else
+
+So nothing changes in how the app works, and nothing can break because of this. Note that the security rating on the app's Info page already goes from 6 to 8 out of 8, which is Home Assistant counting the profile as soon as it exists — it runs ahead of the protection itself until the version that switches it on
+
 ## 1.2.0
 
 Each machine now shows the processor it runs on and how many cores it has, under its name — useful when you have several and their names do not say what they are

--- a/boincui/apparmor.txt
+++ b/boincui/apparmor.txt
@@ -1,0 +1,95 @@
+#include <tunables/global>
+
+# Confinement for the BOINC UI app.
+#
+# Supervisor renames this profile to the app's slug when it installs it (`adjust_profile`), so the
+# name below is only what the file calls itself; the loaded profile is named `local_boincui` or
+# `<repository>_boincui` depending on where the app was installed from.
+#
+# Unlike most Home Assistant apps this one has no s6-overlay or bashio layer to accommodate: the
+# container's entrypoint is `python3 /opt/boincui/main.py`, so the interpreter is PID 1 and this
+# outer profile is the confinement itself rather than a permissive wrapper around a nested one.
+# That is why there is no `file,` or `capability,` blanket rule here -- those grant everything, and
+# nothing in this app needs them.
+#
+# Every rule below was measured against a running container (startup, a rendered page, an activity
+# change against a real BOINC client, and a clean stop), not assumed. What that trace showed:
+#   * exactly one execve -- the interpreter itself, at startup;
+#   * not a single file opened for writing;
+#   * AF_INET stream (the ingress listener and the RPC connections), AF_INET dgram (DNS resolution)
+#     and AF_UNIX stream (asyncio's internal self-pipe socketpair).
+#
+# That trace is a stand-in for the check nobody can run on a development machine: neither the repo's
+# devcontainer nor Docker Desktop has AppArmor in the kernel, so no rule here has ever actually
+# blocked anything.
+#
+# WHICH IS WHY THIS PROFILE SHIPS IN `complain` MODE, AND ENFORCES NOTHING. In that mode AppArmor
+# blocks nothing at all and instead logs every access that *would* have been blocked, so a rule
+# missing from the list below shows up as a log line on a real user's host rather than as an app
+# that will not start. That is the whole point: the rules get their first contact with a real
+# kernel on many machines, at no risk to any of them.
+#
+# Reading the results, on any host running this app:
+#
+#   ha host logs -t kernel | grep 'apparmor="ALLOWED"'
+#
+# Every line naming this profile is a rule that is missing here; it gives the operation and the
+# exact path, so it translates straight into a line below. Expect repeats -- a missing rule on the
+# polling path is logged once per cycle.
+#
+# TO FINISH THE JOB: once that command comes back empty on a host that has been using the app
+# normally for a while, delete `,complain` from the flags line below and release it. Only then does
+# any of this actually confine anything.
+#
+# One caveat to hold on to until that happens: Supervisor rates an app on whether a profile of its
+# name is registered and never looks at the mode (`apparmor` in `apps/model.py`), so Home Assistant
+# already shows this app at 8/8 while the rules below are only being watched. The rating is ahead
+# of the reality, deliberately and temporarily.
+profile boincui flags=(attach_disconnected,mediate_deleted,complain) {
+  #include <abstractions/base>
+  # Resolving a machine configured by hostname rather than by address. Also brings the inet rules
+  # DNS itself needs, which is why there is no `network inet dgram` line below.
+  #include <abstractions/nameservice>
+
+  # No capabilities are granted at all. The app runs as root because Home Assistant apps do, but it
+  # binds an unprivileged port, changes no identity and opens no device, so it needs none -- and
+  # omitting them is what denies them.
+
+  # Talking to BOINC clients over GUI RPC, and serving the page back to ingress. Both directions are
+  # plain TCP; inet6 is here because a machine on the user's LAN may be reached over IPv6, even
+  # though the traced run only used IPv4.
+  network inet stream,
+  network inet6 stream,
+
+  # The interpreter. This is deliberately the only executable in the image the profile will run:
+  # with no other `x` rule, a flaw in the page or a hostile reply from a BOINC client cannot reach
+  # a shell, which is the strongest thing this profile buys.
+  /usr/bin/python3* mrix,
+
+  # Python stats the root directory once while working out its own paths at startup, and no
+  # abstraction grants it. Reading the directory entry gives away nothing on its own -- every path
+  # under it still has to be matched by a rule below.
+  / r,
+
+  # The app's own code and its templates. Read-only -- it never writes to them. The Python standard
+  # library and flask/waitress under /usr/lib are already readable through abstractions/base.
+  /opt/ r,
+  /opt/boincui/ r,
+  /opt/boincui/** r,
+
+  # A sys.path entry Python stats at startup and this image does not have. Allowed only so it fails
+  # as "absent" rather than as a denial in the host's audit log; nothing is ever loaded from it.
+  /usr/local/lib/python3*/dist-packages/ r,
+
+  # The app's own data volume, which is where Supervisor writes options.json. Only options.json is
+  # ever read today and nothing is ever written, but a private volume is not worth confining more
+  # tightly than this: the secrets it holds are read, not written, so denying writes would protect
+  # nothing while breaking any future version that wants to keep state.
+  /data/ r,
+  /data/** rw,
+
+  # Werkzeug spools a large enough request body to a temporary file while parsing a form. This app's
+  # forms are a few bytes, so the traced run never touched /tmp -- this is here so that a request
+  # crafted to be big enough fails as a bad request instead of as a server error.
+  /tmp/** rw,
+}

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "1.2.0"
+version: "1.3.0"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"
@@ -22,5 +22,6 @@ schema:
       port: "port?"
       password: "password"
 image: "ghcr.io/hectorespert/addon-boincui"
-apparmor: false
+# `apparmor` defaults to true, and Supervisor loads apparmor.txt as the profile when the file is
+# present, so neither is declared here -- the add-on linter rejects redeclaring a default.
 backup: cold


### PR DESCRIPTION
Closes the `boincui` third of the standing `apparmor: false` item in `TODO.md`.

## Why `boincui` first

It is the one of the three where a profile can claim something strong. It executes no downloaded code and has no shell in its path, so unlike `boinc` it does not have to permit running arbitrary binaries in order to work at all.

`boinc` also cannot benefit on the rating: `rating_security` ends with `if app.access_docker_api or app.with_full_access: rating = 1` — an assignment, not an adjustment — so it is pinned at 1/8 with or without a profile.

## Enabling it is a deletion

`ATTR_APPARMOR` defaults to true and Supervisor uses `apparmor.txt` as the profile whenever the file is present, so `config.yaml` now declares neither — the add-on linter rejects redeclaring a default.

## Every rule is measured

An `strace -f -e trace=file,network` of the real image against a real BOINC client — startup, a rendered page, an activity change against that client, a clean stop — showed:

* **exactly one `execve`**, the interpreter at startup;
* **not one file opened for writing**;
* three socket families: `AF_INET` stream, `AF_INET` dgram (DNS), `AF_UNIX` stream (asyncio's self-pipe).

The rules were written against that list. The profile is short because `abstractions/base` already grants the Python stdlib plus flask and waitress under `/usr/lib`, `signal (receive) peer=unconfined` — without which Docker's SIGTERM would not reach the app and the clean shutdown would break — and the `unix` rules asyncio needs. It grants **no** network rule, so those come from `abstractions/nameservice`, which is also the only reason DNS works. Both are safe to rely on: the profile is parsed by the *host*, and the official `dnsmasq` add-on profile uses `nameservice`.

There is no `file,` or `capability,` blanket rule — those grant everything, which is how the Music Assistant profile earns its rating while confining nothing. `python3` is PID 1 here, so this outer profile *is* the confinement rather than a permissive wrapper around a nested one.

## It ships watching, not enforcing

Neither the repo's devcontainer nor Docker Desktop has AppArmor in the kernel — the devcontainer reports `unsupported: ["apparmor"]` and launches the container with `apparmor=unconfined` — so **no rule here has ever actually blocked anything**, and the strace stands in for a `complain`-mode run that could not be done locally.

Releasing it in `complain` puts the rules in front of real kernels on many hosts at no risk to any of them: a missing rule costs a log line instead of an app that will not start.

**Known cost, measured:** Supervisor rates an app on whether a profile of its name is registered and never looks at its mode, so this reports **8/8 while confining nothing**. The `CHANGELOG.md` entry says so in plain words rather than letting the shield speak for itself.

The follow-up is filed in `TODO.md` with its exit condition: delete `,complain` once `ha host logs -t kernel | grep 'apparmor="ALLOWED"'` comes back empty on a host that has been using the app normally.

## Verification

| check | result |
|---|---|
| `apparmor_parser -Q` (real parser, Debian 13) | parses |
| Supervisor install (devcontainer) | `rating` 6 → 8, `apparmor` `disable` → `profile`, `state: started` |
| loaded profile | `profile local_boincui flags=(attach_disconnected,mediate_deleted,complain)` — renamed to the slug, flag intact |
| unit tests, in the shipped image | 71 passed |
| `smoke.sh boincui` | builds, serves, all URLs relative, clean stop |
| `yamllint .` | clean |
| **enforcement** | **not verified — no AppArmor kernel available on the dev machine** |

The image is unchanged; this is `config.yaml`, a new `apparmor.txt`, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka