### PR TITLE
feat(boinctui): add a nested AppArmor profile, watching before it enforces

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,9 +48,8 @@ The bugs found in the 2026-08-08 review all shipped in `boinc` 3.8.0–3.9.0 —
 
 ## Security / permissions
 
-- [ ] **`apparmor: false` on `boinc` and `boinctui`.** `boincui` now ships a real profile — watching
-  rather than enforcing for now, see Resolved — which leaves the two harder ones. Both were left alone deliberately, not forgotten:
-  each is a different problem from `boincui`, and neither is a quick win.
+- [ ] **`apparmor: false` on `boinc`.** `boincui` and `boinctui` both ship real profiles now —
+  watching rather than enforcing, see Resolved — which leaves the one that is genuinely hard.
 
   **`boinc`: the rating cannot move, so the profile has to be justified on blast radius alone.**
   `rating_security` (`supervisor/apps/utils.py`) ends with `if app.access_docker_api or
@@ -68,11 +67,6 @@ The bugs found in the 2026-08-08 review all shipped in `boinc` 3.8.0–3.9.0 —
 
   Ties to the dead `boinc/apparmor.txt.disable` under Housekeeping — that file is template
   boilerplate for an s6-overlay image this add-on is not, so it is a starting point for nothing.
-
-  **`boinctui` is confining an interactive shell**, which is why it is not simply the `boincui` job
-  again. `run.sh` launches `ttyd`, which spawns `bash` → `boinctui` per ingress session, so the set
-  of executables reachable is "whatever the user types". Its rating is 6 by the same arithmetic
-  `boincui` had (5, −1 for AppArmor, +2 for ingress) — derived from the formula above, not measured.
 
 ## Conformance with the official HA apps docs
 
@@ -285,10 +279,11 @@ The "build a graphical web UI" item that used to dominate this file was answered
 see Resolved for what was decided and why. What follows is what it did **not** settle, in rough order
 of cost.
 
-- [ ] **Switch `boincui`'s AppArmor profile from `complain` to enforcing.** 1.3.0 ships it watching
-  only, and its `CHANGELOG.md` promises a later version that switches it on, so this is a commitment
-  to a user rather than an idea. **The work is deleting `,complain` from the flags line** in
-  `boincui/apparmor.txt`; everything else is deciding when.
+- [ ] **Switch the AppArmor profiles from `complain` to enforcing — `boincui` and `boinctui` both.**
+  `boincui` 1.3.0 and `boinctui` 2.5.0 ship them watching only, and both changelogs promise a later
+  version that switches them on, so this is a commitment to a user rather than an idea. **The work is
+  deleting `complain` from the flags line** — but in `boinctui/apparmor.txt` there are **two** such
+  lines, because a nested profile carries its own mode and the inner one is the half that matters.
 
   **The gate:** `ha host logs -t kernel | grep 'apparmor="ALLOWED"'` comes back with nothing naming
   the profile, on a host that has been running the app normally for a while — ideally more than one,
@@ -741,6 +736,38 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     itself.
 
   Between them, the recovery that gotcha 6 in `SKILL.md` documents actually works unattended now.
+
+## Shipped in `boinctui` 2.5.0
+
+- [x] **An AppArmor profile for `boinctui`, 6/8 → 8/8, nested and in `complain` like `boincui`'s.**
+  - **The old entry here was wrong, and measuring it is what corrected it.** It claimed this add-on
+    "is confining an interactive shell … the set of executables reachable is whatever the user
+    types", and used that to file it as the harder job. Neither half holds. `ttyd` runs
+    `bash -c "HOME=… exec boinctui"`, and that `exec` replaces the shell, so no prompt is ever
+    reachable; and the `boinctui` binary contains no `system`, `popen`, `exec*` or `fork` and no
+    reference to a shell or `$EDITOR` — checked with a method verified against the same binary,
+    which does find `socket`, `connect` and `curses` in it. A traced session confirms it: the set of
+    programs ever executed is closed and is six — `bash`, `mkdir`, `chown`, `id`, `ttyd`, `boinctui`.
+  - **Nested, unlike `boincui`'s flat profile, because there really are two privilege domains.**
+    `run.sh` runs as root and needs exactly three capabilities — `chown` for `chown -R` on the data
+    directory (measured: `fchownat(… , 1000, 1000)`), and `setuid`/`setgid` for ttyd's `-u`/`-g`. The
+    session ttyd then spawns runs as uid 1000 and needs none, and it is the only part exposed to
+    what a BOINC client sends and to what the user does in the browser. It gets a `cx -> session`
+    sub-profile with no capability rule at all.
+  - **The transition is on `boinctui`, not on `bash`**, because `run.sh` and the session shell are
+    the same binary and no rule can tell them apart. Harmless: the shell only ever execs `boinctui`,
+    and ttyd has already dropped privileges by then, so the window is one exec long and unprivileged
+    anyway — the kernel drops the capabilities at `setuid` regardless of what the profile grants.
+  - **`/usr/bin/env` needs its own `x` rule** and omitting it would stop the app before a line of
+    `run.sh` ran: the script starts `#!/usr/bin/env bash`, so the kernel execs `env` as the
+    interpreter and AppArmor mediates that exec too. Found by reading the trace.
+  - **`/usr/share/terminfo/**` is not covered by `abstractions/base`** and ncurses needs it. The pty
+    (`/dev/ptmx`, `/dev/pts/*`, `/dev/tty`) needs rules as well.
+  - **No rule may name either profile.** `adjust_profile` rewrites only the first line matching
+    `^profile `, so a `peer=boinctui` would survive the rename and then point at a profile that does
+    not exist. The signal rules are therefore written without a `peer=`. Verified on a running
+    Supervisor: the outer profile is stored as `local_boinctui` while the indented `profile session`
+    keeps its own name, and both carry the `complain` flag.
 
 ## Shipped in `boincui` 1.3.0
 

--- a/boinctui/CHANGELOG.md
+++ b/boinctui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0
+
+boinctui now comes with a security profile: the list of the only things it should ever need to do, with the terminal session you actually use held to the shortest list of all. For now the profile only watches and stops nothing, so the list can be proved right on real installations before a later version switches it on. The security rating on the Info page goes from 6 to 8 out of 8 as soon as the profile exists, so it runs ahead of the protection itself until then. Nothing changes in how the app works
+
 ## 2.4.2
 
 The app icon is no longer slightly squashed in the app store

--- a/boinctui/apparmor.txt
+++ b/boinctui/apparmor.txt
@@ -1,0 +1,140 @@
+#include <tunables/global>
+
+# Confinement for the boinctui app.
+#
+# Supervisor renames this profile to the app's slug when it installs it (`adjust_profile`), so the
+# name below is only what the file calls itself. It rewrites the first line matching `^profile ` and
+# nothing else, which is why the nested profile further down stays indented and keeps its own name,
+# and why no rule here may refer to either profile by name -- a `peer=boinctui` would survive the
+# rename and then point at a profile that does not exist.
+#
+# This add-on has two privilege domains, and that is the whole reason the profile is nested rather
+# than flat:
+#
+#   * `/run.sh` runs as root. It creates /data/boinctui, chowns it to the boinctui user, and execs
+#     ttyd, which itself drops to that user with `-u`/`-g`. That part legitimately needs three
+#     capabilities.
+#   * the session ttyd then spawns -- `bash -c "exec boinctui"` -- runs as uid 1000 and needs no
+#     capability at all. It is also the only part exposed to anything hostile: whatever a BOINC
+#     client sends back over the network, and whatever the user does in the browser. So it gets its
+#     own profile below, with no capability rules whatsoever.
+#
+# Everything here was measured against a real ttyd session driven through a browser, talking to a
+# real BOINC client, traced with `strace -f` across the whole process tree. What that showed:
+#   * the set of programs ever executed is closed and is six: bash, mkdir, chown, id, ttyd and
+#     boinctui. No other `x` rule is needed, and none is granted.
+#   * `boinctui` cannot start a process at all -- its binary contains no `system`, `popen`, `exec*`
+#     or `fork`, and no reference to a shell or to $EDITOR, checked with a method that does find
+#     `socket`, `connect` and `curses` in that same binary. `bash -c "exec boinctui"` replaces
+#     itself, so no shell is reachable from the terminal the user is looking at.
+#   * the only privileged operations are `fchownat` on /data/boinctui as root, and ttyd's own drop
+#     to uid/gid 1000.
+#   * sockets: AF_INET stream (the RPC connection and ttyd's listener), AF_INET dgram and
+#     AF_NETLINK raw (DNS), and AF_UNIX stream (libwebsockets' internals).
+#
+# LIKE `boincui`, THIS SHIPS IN `complain` MODE AND ENFORCES NOTHING. AppArmor blocks nothing and
+# instead logs every access that would have been blocked, so a missing rule shows up as a log line
+# on a real host rather than as an app that will not start -- which matters more here than it did
+# for boincui, because this one changes privileges and allocates a pty. No rule below has ever
+# actually blocked anything: neither the repo's devcontainer nor Docker Desktop has AppArmor in the
+# kernel. Read the results on any host running this app with:
+#
+#   ha host logs -t kernel | grep 'apparmor="ALLOWED"'
+#
+# TO FINISH THE JOB: once that comes back empty after normal use, delete `complain` from the flags
+# on BOTH profiles below. A nested profile carries its own mode, so removing it from the outer one
+# alone would leave the session still merely watched -- and that is the half that matters.
+#
+# Until then Home Assistant shows this app at 8/8, because Supervisor rates an app on whether a
+# profile of its name is registered and never looks at the mode. The rating is ahead of the reality,
+# deliberately and temporarily.
+profile boinctui flags=(attach_disconnected,mediate_deleted,complain) {
+  #include <abstractions/base>
+  # `id` and bash resolve the boinctui user through this; it also carries the rules DNS needs.
+  #include <abstractions/nameservice>
+
+  # Only usable while the process is still root, which is `run.sh` and ttyd's own startup: the
+  # kernel drops them the moment ttyd calls setuid, so nothing downstream can use them even in the
+  # outer profile. `chown` is for `chown -R` on the data directory, the other two are ttyd's `-u`
+  # and `-g`.
+  capability chown,
+  capability setuid,
+  capability setgid,
+
+  # ttyd signals a session when its browser tab goes away. Written without a `peer=` on purpose --
+  # naming either profile here would not survive Supervisor's rename, see the note at the top.
+  signal (send) set=(kill,term,int,hup,cont),
+  signal (receive),
+
+  # ttyd's listener on 7681, which is what ingress connects to.
+  network inet stream,
+  network inet6 stream,
+
+  # Stat'd while resolving paths at startup, and granted by no abstraction. Reading the root
+  # directory entry gives away nothing on its own -- everything under it still needs a rule.
+  / r,
+
+  # The entrypoint. `/usr/bin/env` is here because run.sh starts with `#!/usr/bin/env bash`, so the
+  # kernel execs env as the interpreter and AppArmor mediates that too -- omitting it stops the app
+  # before a single line of the script runs.
+  /run.sh rix,
+  /usr/bin/env mrix,
+  /{usr/,}bin/bash mrix,
+
+  # The three helpers run.sh calls, and nothing else.
+  /usr/bin/{mkdir,chown,id} mrix,
+
+  # The terminal server itself.
+  /usr/local/bin/ttyd mrix,
+
+  # Allocating the pty each session runs on.
+  /dev/ptmx rw,
+  /dev/pts/* rw,
+  /dev/tty rw,
+
+  # The data directory: created, chowned, and used as the boinctui user's home.
+  /data/ r,
+  /data/boinctui/ rw,
+  /data/boinctui/** rw,
+
+  # ncurses reads the terminal description, and abstractions/base covers none of it. Both paths are
+  # needed and both forms of each: it searches /etc/terminfo first, and the directories themselves
+  # are stat'd, which `/**` alone does not match.
+  /etc/terminfo/{,**} r,
+  /usr/share/terminfo/{,**} r,
+
+  # The session, in its own profile with no capabilities. The transition is on boinctui rather than
+  # on bash because both this script and the session shell are the same binary and a rule cannot
+  # tell them apart -- but the shell only ever execs boinctui, and by then ttyd has already dropped
+  # privileges, so the window is a single exec long and unprivileged throughout.
+  /usr/bin/boinctui cx -> session,
+
+  profile session flags=(attach_disconnected,mediate_deleted,complain) {
+    #include <abstractions/base>
+    # Reaching a BOINC client configured by hostname, and reading /etc/passwd for the user's home.
+    #include <abstractions/nameservice>
+
+    # No capability rule appears here, deliberately: this is the part of the app that reads what a
+    # BOINC client sends and what the user types, and it needs none.
+
+    signal (receive),
+
+    # The GUI RPC connection to each BOINC client.
+    network inet stream,
+    network inet6 stream,
+
+    / r,
+    /usr/bin/boinctui mr,
+
+    # Its home: `.boinctui.cfg` holds the machines the user configured, and `boinctui.log`.
+    /data/boinctui/ r,
+    /data/boinctui/** rw,
+
+    /etc/terminfo/{,**} r,
+    /usr/share/terminfo/{,**} r,
+
+    # The terminal it draws on, already opened by ttyd.
+    /dev/pts/* rw,
+    /dev/tty rw,
+  }
+}

--- a/boinctui/config.yaml
+++ b/boinctui/config.yaml
@@ -1,5 +1,5 @@
 name: boinctui
-version: "2.4.2"
+version: "2.5.0"
 slug: boinctui
 description: Fullscreen text mode manager for BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinctui"
@@ -11,5 +11,6 @@ ingress: true
 ingress_port: 7681
 panel_icon: mdi:console
 image: "ghcr.io/hectorespert/addon-boinctui"
-apparmor: false
+# `apparmor` defaults to true, and Supervisor loads apparmor.txt as the profile when the file is
+# present, so neither is declared here -- the add-on linter rejects redeclaring a default.
 backup: cold


### PR DESCRIPTION
Second of the three add-ons in the standing `apparmor: false` item, after `boincui` #143. Leaves only `boinc`.

## The backlog entry for this was wrong, and measuring it is what corrected it

`TODO.md` filed `boinctui` as the hard one: *"confining an interactive shell … the set of executables reachable is whatever the user types"*. Neither half holds.

* `ttyd` runs `bash -c "HOME=… exec boinctui"`, and that `exec` **replaces** the shell — no prompt is ever reachable.
* the `boinctui` binary contains no `system`, `popen`, `exec*` or `fork`, and no reference to a shell or `$EDITOR` — checked with a method verified against the same binary, which *does* find `socket`, `connect` and `curses` in it.

A traced session driven through a browser against a real BOINC client confirms it: **the set of programs ever executed is closed and is six** — `bash`, `mkdir`, `chown`, `id`, `ttyd`, `boinctui`. This add-on turned out to be *more* tractable than `boincui`, not less.

## Why nested rather than flat

There are two genuine privilege domains, which is exactly the case the `dnsmasq` idiom exists for:

| | runs as | needs |
|---|---|---|
| `run.sh` → `mkdir`, `chown`, `id`, `ttyd` | root | `capability chown` (measured: `fchownat(…, 1000, 1000)`), `setuid`, `setgid` (ttyd's `-u`/`-g`) |
| `bash` → `boinctui` (the session) | uid 1000 | **nothing** |

The session is the only part exposed to what a BOINC client sends back and to what the user does in the browser, so it gets a `cx -> session` sub-profile with **no capability rule whatsoever**.

The transition is on `boinctui`, not on `bash`, because `run.sh` and the session shell are the same binary and no rule can tell them apart. That costs nothing: the shell only ever execs `boinctui`, ttyd has already dropped privileges, and the kernel drops the capabilities at `setuid` regardless of what the profile grants.

## Two rules that would have broken startup

Both found by reading the trace, not by anything failing:

* **`/usr/bin/env` needs its own `x` rule.** `run.sh` starts `#!/usr/bin/env bash`, so the kernel execs `env` as the interpreter and AppArmor mediates that exec too. Without it the app dies before the first line of the script.
* **terminfo needs four rules, not one.** ncurses searches `/etc/terminfo` *before* `/usr/share/terminfo`, and the directories themselves are stat'd, which a `/**` rule does not match. `abstractions/base` covers none of it.

## Naming trap

No rule names either profile. `adjust_profile` rewrites only the first line matching `^profile `, so a `peer=boinctui` would survive the rename and then point at a profile that does not exist — the signal rules are written without a `peer=` for that reason.

## It ships watching, not enforcing

Same as `boincui` 1.3.0, and it matters more here: this one changes privileges and allocates a pty. **There are two `complain` flags to delete when it is switched on** — a nested profile carries its own mode, and the inner one is the half that matters. Recorded in `TODO.md`, whose flip item now covers both add-ons.

As with `boincui`, Supervisor reports 8/8 while nothing is confined; the `CHANGELOG.md` entry says so.

## Verification

| check | result |
|---|---|
| `apparmor_parser -Q` (real parser) | parses; exactly one `^profile` line, so Supervisor's `get_profile_name` accepts it |
| Supervisor install (devcontainer) | `rating` 6 → 8, `apparmor` `disable` → `profile`, `state: started` |
| loaded profile | outer stored as `local_boinctui`, indented `profile session` keeps its own name, both `complain` |
| `smoke.sh boinctui` | ttyd serves the terminal UI (HTTP 200) |
| `yamllint .` | clean |
| **enforcement** | **not verified — no AppArmor kernel available on the dev machine** |

The image is unchanged; this is `config.yaml`, a new `apparmor.txt`, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka