### PR TITLE
fix(boincui): grant the Python tree its profile could not start without

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,14 +65,8 @@ The bugs found in the 2026-08-08 review all shipped in `boinc` 3.8.0–3.9.0 —
   repo's devcontainer. Every line it does return names an operation and an exact path, which is
   directly the rule to add.
 
-  **One gap is already known without waiting for a log, in `boincui`.** Its profile grants
-  `/opt/boincui/** r` and the interpreter itself, but nothing for the interpreter's own tree, and
-  `abstractions/base` covers only `**.so*` — the extension modules, not the `.py` files beside them.
-  Enforced as written, Python could not import its standard library and the app would not start.
-  `boinc/apparmor.txt` has the rule (`/usr/lib/python3*/{,**} mr,` and the two dist-packages paths,
-  `mr` rather than `r`); `boincui` needs the same three lines. Deliberately **not** folded into
-  `boinc` 3.11.0: `apparmor.txt` is now in `monitored_files`, so touching that file releases
-  `boincui`, and one release should do one thing. `boinctui` is unaffected — no Python in it.
+  **The one gap that was known without waiting for a log is fixed** — `boincui` 1.3.1, see Resolved.
+  Nothing else is known to be missing, which is exactly what the soak is for.
 
   **`boinc` needs the longest soak, and can be flipped separately.** Its profile is the only one
   making a claim about code nobody here has read: the client executes binaries downloaded from
@@ -865,6 +859,25 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
     dragged `boinc` into the release gate. A profile change now releases its own add-on and only its
     own. `CLAUDE.md`'s over-match example was rewritten around this, since it used to cite the
     deleted path.
+
+## Shipped in `boincui` 1.3.1
+
+- [x] **The 1.3.0 profile could not have been enforced: it granted nothing for the Python
+  interpreter's own tree.** Found while writing `boinc/apparmor.txt`, not by a log line, and the
+  profile's own comment asserted the opposite — that `abstractions/base` already covered the standard
+  library and flask/waitress. It does not: base grants `/{usr/,}lib{,32,64}/**.so*  mr,`, the
+  extension modules and nothing else. **Counted on a traced run: of the 326 paths `boincui` opens
+  under `/usr/lib`, 9 match that rule and 317 do not** — the standard library's `.pyc` files being
+  most of them. Enforced as written, Python could not have imported its own standard library and the
+  app would not have started.
+  - Fixed with two rules, `/usr/lib/python3*/{,**} mr,` and `/usr/lib/python3/dist-packages/{,**} mr,`
+    — the same lines `boinc/apparmor.txt` carries, and the false comment above them is now the
+    measurement instead.
+  - Nothing changed for a user: the profile is in `complain` mode, so a missing rule blocked nothing.
+    That is precisely the risk `complain` exists to absorb, and this is the first time it paid.
+  - `boinctui` is unaffected — no Python in it. `boinc` had the rules from the start.
+  - Kept out of `boinc` 3.11.0 on purpose: `apparmor.txt` had just joined `monitored_files`, so
+    touching that file releases its add-on, and one release should do one thing.
 
 ## Shipped as `boincui`, 0.1.0 → 1.0.0
 

--- a/boincui/CHANGELOG.md
+++ b/boincui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+The security profile added in 1.3.0 was missing part of its list, and as written it would have stopped the app from starting once a later version switches the profile on. Nothing changes today — the profile still only watches and stops nothing, and the app runs exactly as before. The correction is here so that switching it on later is a change you do not notice
+
 ## 1.3.0
 
 BOINC UI now comes with a security profile: the list of the only things it should ever need to do, which is read its own settings and talk to the machines you listed. For now the profile only watches and stops nothing, so the list can be proved right on real installations before a later version switches it on. The security rating on the Info page goes from 6 to 8 out of 8 as soon as the profile exists, so it runs ahead of the protection itself until then. Nothing changes in how the app works

--- a/boincui/apparmor.txt
+++ b/boincui/apparmor.txt
@@ -71,11 +71,24 @@ profile boincui flags=(attach_disconnected,mediate_deleted,complain) {
   # under it still has to be matched by a rule below.
   / r,
 
-  # The app's own code and its templates. Read-only -- it never writes to them. The Python standard
-  # library and flask/waitress under /usr/lib are already readable through abstractions/base.
+  # The app's own code and its templates. Read-only -- it never writes to them, and with
+  # PYTHONDONTWRITEBYTECODE set in the Dockerfile it never tries to leave a __pycache__ here either.
   /opt/ r,
   /opt/boincui/ r,
   /opt/boincui/** r,
+
+  # The interpreter's own tree: the standard library, and flask/waitress/jinja2 from Debian.
+  #
+  # 1.3.0 claimed abstractions/base already covered this and it does not. Base grants
+  # `/{usr/,}lib{,32,64}/**.so*  mr,` -- the extension modules and nothing else. Counted on a traced
+  # run: of the 326 paths this app opens under /usr/lib, **9** match that rule and **317** do not,
+  # the .pyc files of the standard library being most of them. Enforced without these two lines,
+  # Python could not import its own standard library and the app would not start at all.
+  #
+  # `mr` rather than `r` to match `boinc/apparmor.txt`: the mapping is what lib-dynload needs, and
+  # granting it on read-only interpreter files beside them costs nothing.
+  /usr/lib/python3*/{,**} mr,
+  /usr/lib/python3/dist-packages/{,**} mr,
 
   # A sys.path entry Python stats at startup and this image does not have. Allowed only so it fails
   # as "absent" rather than as a denial in the host's audit log; nothing is ever loaded from it.

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -1,5 +1,5 @@
 name: BOINC UI
-version: "1.3.0"
+version: "1.3.1"
 slug: boincui
 description: Graphical web interface to monitor and control the BOINC client
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"


### PR DESCRIPTION
> **Stacked on #145.** Base is `boinc-apparmor`, so the diff shown here is only this change; GitHub retargets it to `main` automatically once #145 merges. Merge #145 first.

`boincui` 1.3.1. The profile shipped in 1.3.0 could not have been enforced.

## What was wrong

Its own comment said so, and was wrong:

> The Python standard library and flask/waitress under /usr/lib are already readable through abstractions/base.

`abstractions/base` grants `/{usr/,}lib{,32,64}/**.so*  mr,` — the extension modules, and nothing else. The `.py` and `.pyc` files beside them match no rule in the profile at all.

Counted on a traced run (`strace -ff -e trace=file`, real image, startup plus a rendered page):

| paths opened under `/usr/lib` | |
|---|---|
| total | 326 |
| matching base's `**.so*` | **9** |
| matching nothing in the profile | **317** |

The 317 are the standard library's `__pycache__/*.pyc` (most of them), the stdlib package directories, and flask, jinja2, click, blinker and waitress under `dist-packages`. Enforced as written, Python could not have imported its own standard library and the app would not have started.

`/usr/lib/locale/**` and the gconv modules *are* covered by base, so they are not in the fix.

## The fix

The two rules `boinc/apparmor.txt` already carries:

```
/usr/lib/python3*/{,**} mr,
/usr/lib/python3/dist-packages/{,**} mr,
```

`mr` rather than `r` for consistency with that file — the mapping is what `lib-dynload` needs, and granting it on read-only interpreter files beside them costs nothing. The comment that asserted the opposite is replaced by the count above.

Also corrected in passing: the note on `/opt/boincui/**` now says why nothing is ever written there (`PYTHONDONTWRITEBYTECODE` in the Dockerfile), which the same trace confirms — zero files opened for writing anywhere.

## What changes for a user

Nothing. The profile is in `complain` mode, so the missing rule blocked nothing and the app has been running normally. **This is the first time releasing in `complain` mode paid for itself**: a mistake that would have been a dead app on every install was instead a mistake with no consequences at all.

## Why not in #145

`apparmor.txt` joins CI's `monitored_files` in that PR, so touching that file releases its own add-on — and one release should do one thing.

## Verification

- `apparmor_parser -Q -K boincui/apparmor.txt` — parses clean
- 71 `boincui` tests pass, run inside the shipped image
- traced run serves `HTTP 200` and logs a clean startup and stop
- `yamllint .` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka