### PR TITLE
docs: record why init: false is right in all three apps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -115,23 +115,6 @@ findings measured directly against the Supervisor in `.devcontainer`.
   Dockerfile. Work out the supported replacement before removing anything — the `build_from` regex
   bug fixed in `boinc` 3.8.0 / `boinctui` 2.4.1 was found exactly here.
 
-- [ ] **`init: false` is not justified by the documented reason, and `main.py` silently depends on
-  it.** The docs say to disable `init` only when the image has its own init system (s6-overlay);
-  neither image does. Two consequences before changing it:
-  1. The Protection Mode detection at `boinc/operator/main.py:31` (`if current_pid == 1`) is an
-     *undocumented implicit dependency on `init: false`* — it works only because nothing else
-     occupies PID 1. Setting `init: true` would put Docker's init there and silently disable the
-     warning the whole README leads with. This coupling deserves a comment in the code at minimum.
-  2. With no init process, orphaned grandchildren are never reaped. For `boinc` this is masked by
-     `host_pid: true`; for `boinctui`, `ttyd` is PID 1 and spawns `bash` → `boinctui` per session,
-     so zombie accumulation across many ingress sessions is plausible. Check `ps` inside a
-     long-lived `boinctui` container before deciding.
-
-- [ ] **Only `build-addons.yaml` still hardcodes an add-on name**, in the post-build test step
-  (`if: inputs.addon == 'boinc'`). Everything else discovers add-ons by globbing for `config.yaml`.
-  Worth generalising if a second add-on ever wants a post-build check. Its `manifest` job also maps
-  architectures by name (`amd64`, `aarch64`), so a new arch needs that `case` extended.
-
 ### Confirmed correct — checked, no action needed
 
 - **Option types are right as they stand, and the old item about them was half stale (2026-08-15).**
@@ -394,6 +377,44 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
 # Resolved — kept so it is not re-litigated
 
 ## Discarded after investigation
+
+- [x] **`init: false` is right in all three, for a reason the HA docs do not list (measured
+  2026-08-16).** The item asked why it was set, since the documented justification — the image ships
+  its own init (s6-overlay) — is false here: all three build from bare `debian:13.5-slim` and the
+  `ENTRYPOINT` *is* the working process. Both halves are now settled and written into the three
+  `config.yaml` files next to the flag, which is where someone about to flip it will be looking.
+  - **`boinc` must keep it, and it is load-bearing.** The Protection Mode warning
+    (`boinc/operator/main.py:39`) works by testing `os.getpid() == 1`: Supervisor grants `host_pid`
+    only when Protection Mode is *off*, so PID 1 is exactly the confined case. `init: true` would put
+    Docker's init at PID 1 and silently drop the warning the whole README leads with — no error, no
+    failing test. `main.py:35-38` already carried a comment saying so; the gap was `config.yaml`
+    saying nothing.
+  - **The zombie worry was unfounded, and the process tree is not what the item assumed.** It
+    predicted `ttyd → bash → boinctui` per session, accumulating unreaped grandchildren across
+    ingress sessions. Measured against the built image: during a live session the table is `1 ttyd`
+    and `65 boinctui` with **PPID 1** — no shell in between, because `run.sh:20` is
+    `bash -c "… exec boinctui"` and the `exec` replaces it. A direct child is reaped by its parent,
+    not by init. Ten sessions opened and abruptly closed (raw websocket client against `/ws`, which
+    is what actually makes ttyd spawn — a TCP connect does not) left **zero processes in state `Z`**.
+    `run.sh`'s own `mkdir`/`chown`/`id` leave nothing either: it `exec`s into ttyd, so bash is gone.
+  - `boincui` never had a question: `main.py` is PID 1 and starts no child process at all.
+  - Signal forwarding, the other thing an init would provide, is already handled by hand —
+    `main.py` forwards `SIGHUP`/`SIGINT`/`SIGQUIT`/`SIGTERM` to the client (see `boinc` 3.8.5).
+  - No behaviour changed, so no version bump: this was comments and backlog.
+
+- [x] **The hardcoded `boinc` in `build-addons.yaml` stays as it is (decided 2026-08-16).** The
+  post-build smoke test is guarded by `if: inputs.addon == 'boinc'`
+  (`.github/workflows/build-addons.yaml:101-116`) — the only place in the pipeline that names an
+  add-on, since everything else discovers them by globbing for `config.yaml`. Generalising it (a
+  per-add-on `test.sh` the workflow runs when present, say) buys nothing today: the command is
+  genuinely `boinc`-specific — `--pid=host`, `--uts=host`, the `/data` volume, the operator's
+  `options.json` — so the abstraction would have exactly one implementation. Revisit only if a
+  second add-on actually gets a post-build check in CI.
+  **The arch `case` in the `manifest` job is the part with a real failure mode**, and it is left
+  standing knowingly: it maps `amd64`/`aarch64` and treats anything else as
+  `::warning:: … skipping check`, so adding `armv7`/`armhf`/`i386` to a `build.yaml` would let a
+  missing platform pass the manifest verification in green. Nothing builds those today; extend the
+  `case` in the same commit if that ever changes.
 
 - [x] **A Home Assistant entity surface is not this repo's job (decided 2026-08-11).** Three items
   used to sit here — link SpuelMett's integration, build HA-native sensors, expose a Prometheus

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -6,6 +6,11 @@ url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"
 arch:
   - aarch64
   - amd64
+# Not for the documented reason ("the image has its own init system") — this one has none. The
+# operator has to *be* PID 1: it detects Protection Mode by checking for it (operator/main.py),
+# which works only because Supervisor grants host_pid solely when Protection Mode is off. Setting
+# `init: true` would put Docker's init at PID 1 and silently disable that warning. Nothing is left
+# unreaped either, since host_pid puts the container in the host's namespace.
 init: false
 ports:
   31416/tcp: null

--- a/boinctui/config.yaml
+++ b/boinctui/config.yaml
@@ -6,6 +6,11 @@ url: "https://github.com/hectorespert/boinc-addons/tree/main/boinctui"
 arch:
   - aarch64
   - amd64
+# Not for the documented reason ("the image has its own init system") — this one has none. ttyd is
+# PID 1 and reaps its own children: run.sh execs into it, and each session is
+# `bash -c "... exec boinctui"`, so the session process is a *direct* child of ttyd with no shell
+# left in between. Measured 2026-08-16 — ten sessions opened and closed left no zombie — so Docker's
+# init would add a process with nothing to collect.
 init: false
 ingress: true
 ingress_port: 7681

--- a/boincui/config.yaml
+++ b/boincui/config.yaml
@@ -6,6 +6,8 @@ url: "https://github.com/hectorespert/boinc-addons/tree/main/boincui"
 arch:
   - aarch64
   - amd64
+# Not for the documented reason ("the image has its own init system") — this one has none. main.py
+# is PID 1 and starts no child process at all, so Docker's init would have nothing to reap.
 init: false
 ingress: true
 panel_icon: mdi:chart-box


### PR DESCRIPTION
> [!IMPORTANT]
> **Aparcado a propósito. No mergear tal cual: CI fallará.**
>
> Solo cambian comentarios, así que no lleva bump de versión — pero `config.yaml` está en
> `monitored_files`, y `check-version` en modo estricto rechaza los tres add-ons porque sus tags ya
> existen (`.github/workflows/check-version.yaml:54`). En el PR el check es informativo y pasa; el
> fallo llega al mergear a `main`.
>
> **Decisión tomada: se agrupa con el próximo cambio real.** Para desaparcarlo:
>
> 1. Rebasar esta rama sobre la rama que sí trae un cambio de comportamiento, o traer aquí ese cambio.
> 2. Subir la versión de **cada uno de los tres** `config.yaml` — los tres aparecen como cambiados,
>    así que los tres necesitan una versión mayor que su último tag (`boinc-v3.11.0`,
>    `boinctui-v2.5.0`, `boincui-v1.3.1`), aunque el cambio real solo toque a uno.
> 3. Añadir la entrada de `CHANGELOG.md` de cada uno describiendo **el cambio real**, no esto: un
>    comentario en `config.yaml` no es algo que el usuario lea en el diálogo de Update.
> 4. Quitar el estado de borrador.
>
> Si esto se repite —y se repetirá, porque los tres `config.yaml` ya llevan comentarios largos
> explicando decisiones— la solución de fondo es que el gate de versión ignore los cambios que solo
> tocan comentarios, en `find-changed-addons.yaml`. Eso es trabajo aparte.

---

## Qué hace

Escribe en los tres `config.yaml`, junto al flag, por qué `init: false` es correcto. Cierra el ítem correspondiente de `TODO.md`, moviéndolo a *Discarded after investigation*.

La documentación de HA justifica `init: false` solo cuando la imagen trae su propio init (s6-overlay). Ninguna de las tres lo trae: parten de `debian:13.5-slim` pelado y el `ENTRYPOINT` es directamente el proceso de trabajo. Así que el flag lleva tiempo pareciendo injustificado a cualquiera que lo lea. No lo está — simplemente las razones reales no estaban escritas al lado.

## Las dos razones

**`boinc` tiene que mantenerlo, y es carga estructural.** El aviso de Protection Mode (`boinc/operator/main.py:39`) comprueba `os.getpid() == 1`, y eso funciona únicamente porque Supervisor concede `host_pid` solo cuando Protection Mode está desactivado. Poner `init: true` metería el init de Docker en el PID 1 y desactivaría en silencio el aviso con el que arranca todo el README — sin error y sin test que falle. `main.py:35-38` ya lo decía; lo que no decía nada era `config.yaml`.

**El miedo a los zombies era infundado, y el árbol de procesos no era el que suponía el ítem.** Predecía `ttyd → bash → boinctui` por sesión de ingress, acumulando nietos sin recoger. Medido contra la imagen construida, durante una sesión viva:

```
PID    PPID   ST  COMM
1      0      S   ttyd
65     1      S   boinctui      <- PPID 1, sin shell intermedio
```

No hay bash en medio porque `run.sh:20` es `bash -c "… exec boinctui"` y el `exec` lo reemplaza. Un hijo directo lo recoge su padre, no el init. Diez sesiones abiertas y cerradas de golpe dejaron **cero** procesos en estado `Z`. Los `mkdir`/`chown`/`id` de `run.sh` tampoco dejan nada: el script hace `exec ttyd` y desaparece.

Detalle que hace este test menos trivial de lo que parece: ttyd **no lanza el proceso al conectar el socket**, sino al recibir el primer mensaje JSON por el websocket. Un `curl` o un `nc` no prueban nada; hizo falta un cliente websocket real contra `/ws`. Cada sesión devolvió ~5,4 KB de la UI de `boinctui` renderizando.

`boincui` nunca tuvo pregunta: `main.py` es PID 1 y no lanza ningún hijo.

El reenvío de señales, lo otro que aportaría un init, ya está hecho a mano: `main.py` reenvía `SIGHUP`/`SIGINT`/`SIGQUIT`/`SIGTERM` al cliente desde `boinc` 3.8.5.

## ⚠️ Esto no se puede mergear tal cual

Solo cambian comentarios, así que **no hay bump de versión ni entrada de changelog**. Pero `config.yaml` está en `monitored_files`, así que `find-changed-addons` marca los tres add-ons como cambiados y `check-version` en modo estricto fallará en los tres al llegar a `main`: los tags `boinc-v3.11.0`, `boinctui-v2.5.0` y `boincui-v1.3.1` ya existen (`.github/workflows/check-version.yaml:54`).

En el PR el check es informativo, así que aquí pasará. El fallo llega al mergear. Hay que decidir antes:

1. **Subir el patch de los tres** (3.11.1 / 2.5.1 / 1.3.2) con su entrada de changelog. Cuesta: reconstruye y republica tres imágenes y dispara tres anuncios en Bluesky por un comentario que ningún usuario ve.
2. **Mover los comentarios fuera de `config.yaml`** — a `CLAUDE.md` o a `DEVELOPMENT.md`. Sale gratis en CI, pero pierde justo lo que buscaba el cambio: que el aviso esté donde mira quien va a cambiar el flag.
3. **Excluir cambios que solo tocan comentarios del gate de versión.** Es lo correcto a largo plazo y es trabajo aparte, en `find-changed-addons.yaml`.

Mi recomendación es la 1 si se agrupa con algún cambio real pendiente, y la 3 si esto va a volver a pasar — que volverá, porque los tres `config.yaml` ya llevan comentarios largos explicando decisiones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka
