### PR TITLE
feat(boinc): expose the disk limits and the work buffer as options

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -115,23 +115,6 @@ findings measured directly against the Supervisor in `.devcontainer`.
   Dockerfile. Work out the supported replacement before removing anything — the `build_from` regex
   bug fixed in `boinc` 3.8.0 / `boinctui` 2.4.1 was found exactly here.
 
-- [ ] **`init: false` is not justified by the documented reason, and `main.py` silently depends on
-  it.** The docs say to disable `init` only when the image has its own init system (s6-overlay);
-  neither image does. Two consequences before changing it:
-  1. The Protection Mode detection at `boinc/operator/main.py:31` (`if current_pid == 1`) is an
-     *undocumented implicit dependency on `init: false`* — it works only because nothing else
-     occupies PID 1. Setting `init: true` would put Docker's init there and silently disable the
-     warning the whole README leads with. This coupling deserves a comment in the code at minimum.
-  2. With no init process, orphaned grandchildren are never reaped. For `boinc` this is masked by
-     `host_pid: true`; for `boinctui`, `ttyd` is PID 1 and spawns `bash` → `boinctui` per session,
-     so zombie accumulation across many ingress sessions is plausible. Check `ps` inside a
-     long-lived `boinctui` container before deciding.
-
-- [ ] **Only `build-addons.yaml` still hardcodes an add-on name**, in the post-build test step
-  (`if: inputs.addon == 'boinc'`). Everything else discovers add-ons by globbing for `config.yaml`.
-  Worth generalising if a second add-on ever wants a post-build check. Its `manifest` job also maps
-  architectures by name (`amd64`, `aarch64`), so a new arch needs that `case` extended.
-
 ### Confirmed correct — checked, no action needed
 
 - **Option types are right as they stand, and the old item about them was half stale (2026-08-15).**
@@ -271,15 +254,11 @@ findings measured directly against the Supervisor in `.devcontainer`.
 
 ## Config schema — feature gaps vs. upstream BOINC preferences
 
-`boinc/config.yaml` covers the account manager, remote RPC, a computing window and four CPU knobs.
-Common BOINC global preferences not exposed, each roughly one key away in
-`global_prefs_override.py`:
+`boinc/config.yaml` covers the account manager, remote RPC, a computing window, four CPU knobs and —
+since 3.12.0, see Resolved — the three disk limits and the work buffer. Common BOINC global
+preferences still not exposed, each roughly one key away in `global_prefs_override.py`:
 
-- [ ] `work_buf_min_days` / `work_buf_additional_days` — how much work to keep queued; probably the
-  most-requested BOINC knob after CPU limits. **Also the real lever on backup size** — see the
-  closed `backup_exclude` item in Resolved, which found that the exclusion list is not.
 - [ ] GPU usage toggle (`no_gpus` / `exclude_gpu`) — relevant given `video: true` is already granted.
-- [ ] `disk_max_used_gb` / `disk_max_used_pct` — useful on small HA hosts.
 - [ ] `run_on_batteries` — mostly N/A for typical HA hardware, but trivial to add.
 - [ ] A `suspend`/`no_new_work` boolean, to pause computation from the add-on config without
   detaching.
@@ -388,22 +367,59 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
   also unblocked adding `apparmor.txt` to `monitored_files` — see Resolved.
 - The Dockerfile labels item was **stale and is closed** — see *Confirmed correct* under
   Conformance. They already agree across all three add-ons.
-- **PR #147 is parked in draft, waiting to be grouped with the next real change.** It closes the
-  `init: false` item — comments in the three `config.yaml` files plus the `TODO.md` entry, no
-  behaviour change — and cannot be merged alone: `config.yaml` is in `monitored_files`, so
-  `check-version` marks all three add-ons as changed and rejects them for having versions that
-  already carry a tag (`check-version.yaml:54`). Whoever merges it must bump **all three** patch
-  versions, not just the one the real change touches, and write each `CHANGELOG.md` entry about
-  that real change rather than about the comments. Delete this line in the same merge.
-  The fix that would stop this recurring — and it will recur, all three `config.yaml` files already
-  carry long comments explaining decisions — is teaching `find-changed-addons.yaml` to ignore
-  comment-only diffs. Not attempted.
+- **A comment-only edit to a `config.yaml` cannot ship on its own, so two are parked in draft.**
+  `config.yaml` is in `monitored_files`, so `find-changed-addons` marks the add-on as changed and
+  `check-version` then rejects a version that already carries a tag (`check-version.yaml:54`) — a
+  comment forces a release or waits for one. The `init: false` rationale was written for all three
+  add-ons and split accordingly: `boinc`'s rode along with 3.12.0, and the other two wait for a
+  release of their own. Delete this line once both have merged.
+  The fix that would stop this recurring — and it will recur, all three `config.yaml` files carry
+  long comments explaining decisions — is teaching `find-changed-addons.yaml` to ignore
+  comment-only diffs. Not attempted, and not free: a bug in it would silently skip a real release.
 
 ---
 
 # Resolved — kept so it is not re-litigated
 
 ## Discarded after investigation
+
+- [x] **`init: false` is right in all three, for a reason the HA docs do not list (measured
+  2026-08-16).** The item asked why it was set, since the documented justification — the image ships
+  its own init (s6-overlay) — is false here: all three build from bare `debian:13.5-slim` and the
+  `ENTRYPOINT` *is* the working process. Both halves are now settled and written into the three
+  `config.yaml` files next to the flag, which is where someone about to flip it will be looking.
+  - **`boinc` must keep it, and it is load-bearing.** The Protection Mode warning
+    (`boinc/operator/main.py:39`) works by testing `os.getpid() == 1`: Supervisor grants `host_pid`
+    only when Protection Mode is *off*, so PID 1 is exactly the confined case. `init: true` would put
+    Docker's init at PID 1 and silently drop the warning the whole README leads with — no error, no
+    failing test. `main.py:35-38` already carried a comment saying so; the gap was `config.yaml`
+    saying nothing.
+  - **The zombie worry was unfounded, and the process tree is not what the item assumed.** It
+    predicted `ttyd → bash → boinctui` per session, accumulating unreaped grandchildren across
+    ingress sessions. Measured against the built image: during a live session the table is `1 ttyd`
+    and `65 boinctui` with **PPID 1** — no shell in between, because `run.sh:20` is
+    `bash -c "… exec boinctui"` and the `exec` replaces it. A direct child is reaped by its parent,
+    not by init. Ten sessions opened and abruptly closed (raw websocket client against `/ws`, which
+    is what actually makes ttyd spawn — a TCP connect does not) left **zero processes in state `Z`**.
+    `run.sh`'s own `mkdir`/`chown`/`id` leave nothing either: it `exec`s into ttyd, so bash is gone.
+  - `boincui` never had a question: `main.py` is PID 1 and starts no child process at all.
+  - Signal forwarding, the other thing an init would provide, is already handled by hand —
+    `main.py` forwards `SIGHUP`/`SIGINT`/`SIGQUIT`/`SIGTERM` to the client (see `boinc` 3.8.5).
+  - No behaviour changed, so no version bump: this was comments and backlog.
+
+- [x] **The hardcoded `boinc` in `build-addons.yaml` stays as it is (decided 2026-08-16).** The
+  post-build smoke test is guarded by `if: inputs.addon == 'boinc'`
+  (`.github/workflows/build-addons.yaml:101-116`) — the only place in the pipeline that names an
+  add-on, since everything else discovers them by globbing for `config.yaml`. Generalising it (a
+  per-add-on `test.sh` the workflow runs when present, say) buys nothing today: the command is
+  genuinely `boinc`-specific — `--pid=host`, `--uts=host`, the `/data` volume, the operator's
+  `options.json` — so the abstraction would have exactly one implementation. Revisit only if a
+  second add-on actually gets a post-build check in CI.
+  **The arch `case` in the `manifest` job is the part with a real failure mode**, and it is left
+  standing knowingly: it maps `amd64`/`aarch64` and treats anything else as
+  `::warning:: … skipping check`, so adding `armv7`/`armhf`/`i386` to a `build.yaml` would let a
+  missing platform pass the manifest verification in green. Nothing builds those today; extend the
+  `case` in the same commit if that ever changes.
 
 - [x] **A Home Assistant entity surface is not this repo's job (decided 2026-08-11).** Three items
   used to sit here — link SpuelMett's integration, build HA-native sensors, expose a Prometheus
@@ -621,6 +637,34 @@ None open. The `projects:` list shipped in 3.10.0 — see Resolved.
   new code**: the `niu_` keys stayed in `MANAGED_PREFERENCES`, so a stale value the operator wrote
   itself falls into the removal branch that has existed since 3.8.1, while one set by the user from
   `boinctui` is untouched.
+
+## Shipped in `boinc` 3.12.0
+
+- [x] **The three disk limits and the work buffer are now options** — `disk_max_used_gb`,
+  `disk_max_used_pct`, `disk_min_free_gb`, `work_buf_min_days`, `work_buf_additional_days`. Five
+  entries in `MANAGED_PREFERENCES` and five blocks in `build_managed_preferences`; the three-way
+  merge from 3.8.1 carried the rest unchanged. What the work turned up:
+  - **All three disk limits are exposed, not the pair the old item proposed.** They are independent
+    and the client applies the *least* of the three (`CLIENT_STATE::allowed_disk_usage`,
+    `client/cs_prefs.cpp`), so shipping two of three would have made the third's absence look like a
+    limit that does not exist. `disk_min_free_gb` is also the most useful of them on an HA host: it
+    protects the disk rather than capping science data.
+  - **Zero is meaningful and is not the same as unset.** The client skips a limit whose value is
+    falsy, so `disk_max_used_gb: 0` means *no limit*, while leaving the option out removes the tag
+    and restores BOINC's default. Both paths are covered by tests; the docs say so explicitly,
+    because "0 = unlimited" reads as "0 = allow nothing" to everyone who has not read the source.
+  - **Verified against a running client, since parsing proves nothing** — the client silently drops
+    tags it does not know. `boinccmd` cannot dump effective preferences, so the check went over the
+    GUI RPC (`get_global_prefs_working`, the reply BOINC Manager reads): all five arrived, and after
+    removing four of the five options they came back as exactly the defaults `lib/prefs.cpp` declares
+    (`0`, `90`, `0.1`, `0.5`), while the one still set stayed put.
+  - **Three existing tests had quietly stopped testing what they were named for.** They used
+    `disk_max_used_gb` as the stand-in for "a preference set outside the add-on", which this change
+    made managed — they kept passing while asserting something else. Switched to
+    `ram_max_used_busy_pct`, with a comment naming the trap for whoever exposes that one next.
+  - **Schema note:** `float(0,)` with no upper bound is valid (`RE_SCHEMA_ELEMENT` makes both ends
+    optional) and is used for the two GB limits, because a host can have any amount of storage and
+    an invented ceiling would only ever be wrong.
 
 ## Shipped in `boinc` 3.10.0
 

--- a/boinc/CHANGELOG.md
+++ b/boinc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.12.0
+
+Added five options to control how much of your machine BOINC takes: a cap in gigabytes, a cap as a percentage of the disk, an amount of free space to always leave alone, and how many days of work to keep downloaded and waiting. The strictest disk limit you set is the one that applies. Keeping less work queued is also the way to make this app's backups smaller
+
 ## 3.11.0
 
 BOINC now comes with a security profile: the list of the only things it should ever need to do, with the science applications it downloads held to a far shorter list than the app itself — their own work folder, and no way out to the network or to the rest of your system. For now the profile only watches and stops nothing, so the list can be proved right against real work units before a later version switches it on. The security rating on the Info page does not change: this app needs access that holds it at the lowest score whatever else it does. Nothing changes in how the app works

--- a/boinc/DOCS.md
+++ b/boinc/DOCS.md
@@ -224,6 +224,47 @@ time, is ignored — BOINC computes all the time — and a warning explaining wh
     `cpu_usage_limit`
   - Leave unset to use the same limit in both cases
 
+#### Disk Space Options
+
+Three separate limits. They do not replace each other — BOINC applies whichever one is strictest at
+the time, so you can set one, two or all three. Leave one empty and that particular limit simply
+does not apply.
+
+- **disk_max_used_gb** (optional, minimum: 0)
+  - Never use more than this many gigabytes for science data
+  - Example: `20` keeps everything BOINC downloads and computes under 20 GB
+  - Leave empty for no limit of this kind. `0` also means no limit, not "allow nothing"
+
+- **disk_max_used_pct** (optional, range: 0-100)
+  - Never use more than this percentage of the total size of the disk
+  - Leave empty to keep BOINC's own default of 90%
+  - `0` means no limit of this kind
+
+- **disk_min_free_gb** (optional, minimum: 0)
+  - Always leave at least this many gigabytes free on the disk
+  - The one to reach for on a small machine: it protects the disk itself, so a growing project
+    cannot fill the space Home Assistant needs, whatever the other two say
+
+#### Work Buffer Options
+
+How much work to keep downloaded and waiting. A bigger buffer keeps computing going while the
+internet is down, and costs you in two ways: **your backups get bigger**, because downloaded work is
+included in them, and tasks are likelier to miss their deadlines because they sit in the queue
+longer.
+
+- **work_buf_min_days** (optional, range: 0-30)
+  - How many days of work to keep queued at all times
+  - Example: `0.5` keeps about half a day of work in hand
+  - Leave empty to keep BOINC's own default, which is a small buffer of a few hours
+
+- **work_buf_additional_days** (optional, range: 0-30)
+  - Extra days of work to fetch on top of the minimum, whenever BOINC contacts a project anyway
+  - Raising this makes BOINC ask for work less often, in bigger batches
+  - Set both this and `work_buf_min_days` to `0` to download tasks only as they are needed, which
+    is the smallest this app can get on disk and in backups
+
+Projects may send less work than you ask for — how much they hand out is their decision, not yours.
+
 ### Example Configurations
 
 #### Basic Setup with Account Manager
@@ -262,6 +303,18 @@ account_manager_username: "youremail@example.com"
 account_manager_password: "your_password"
 max_ncpus: 50
 cpu_usage_limit: 75
+```
+
+#### Keeping the Disk and the Backups Small
+
+```yaml
+account_manager_url: "https://scienceunited.org"
+account_manager_username: "youremail@example.com"
+account_manager_password: "your_password"
+disk_max_used_gb: 10
+disk_min_free_gb: 5
+work_buf_min_days: 0
+work_buf_additional_days: 0
 ```
 
 #### Full Speed Only When the Computer Is Not in Use
@@ -307,11 +360,17 @@ file — see [Preferences Override](https://github.com/BOINC/boinc/wiki/PrefsOve
 format. Place it in this app's config folder, which appears as `addon_configs/…_boinc` in the
 File editor and Samba apps.
 
-When that file is present, the app uses it as-is and the `start_hour`, `end_hour`, `max_ncpus`,
-`cpu_usage_limit`, `max_ncpus_idle` and `cpu_usage_limit_idle` options are ignored.
+When that file is present, the app uses it as-is and every option below is ignored: `start_hour`,
+`end_hour`, `max_ncpus`, `cpu_usage_limit`, `max_ncpus_idle`, `cpu_usage_limit_idle`,
+`disk_max_used_gb`, `disk_max_used_pct`, `disk_min_free_gb`, `work_buf_min_days` and
+`work_buf_additional_days`.
 
-Otherwise, the app only manages those six settings. Anything else you set from boinctui or a
-remote BOINC Manager — disk limits, memory, network, work buffer, even a schedule using the same
-start/end time fields — is preserved across restarts and updates. Setting one of the six options
-applies it, and removing it from the options clears it again, without touching preferences you set
-yourself elsewhere.
+Otherwise, the app only manages those eleven settings. Anything else you set from boinctui or a
+remote BOINC Manager — memory, network, and the rest — is preserved across restarts and updates.
+Setting one of the eleven options applies it, and removing it from the options clears it again,
+without touching preferences you set yourself elsewhere.
+
+One thing to know if you already set the disk limits or the work buffer from boinctui or BOINC
+Manager: those values are kept as they are until the first time you fill in the matching option
+here. From then on this app owns that setting, and clearing the option restores BOINC's default
+rather than the value you had set elsewhere.

--- a/boinc/config.yaml
+++ b/boinc/config.yaml
@@ -1,11 +1,16 @@
 name: BOINC
-version: "3.11.0"
+version: "3.12.0"
 slug: boinc
 description: Downloads scientific computing jobs and runs them
 url: "https://github.com/hectorespert/boinc-addons/tree/main/boinc"
 arch:
   - aarch64
   - amd64
+# Not for the documented reason ("the image has its own init system") — this one has none. The
+# operator has to *be* PID 1: it detects Protection Mode by checking for it (operator/main.py),
+# which works only because Supervisor grants host_pid solely when Protection Mode is off. Setting
+# `init: true` would put Docker's init at PID 1 and silently disable that warning. Nothing is left
+# unreaped either, since host_pid puts the container in the host's namespace.
 init: false
 ports:
   31416/tcp: null
@@ -36,6 +41,14 @@ schema:
   cpu_usage_limit: "float(0,100)?"
   max_ncpus_idle: "float(0,100)?"
   cpu_usage_limit_idle: "float(0,100)?"
+  # The disk limits have no upper bound worth inventing -- a host can have any amount of storage --
+  # so only the lower one is declared. Zero is deliberately allowed on the first two: BOINC reads it
+  # as "no limit" rather than "allow nothing".
+  disk_max_used_gb: "float(0,)?"
+  disk_max_used_pct: "float(0,100)?"
+  disk_min_free_gb: "float(0,)?"
+  work_buf_min_days: "float(0,30)?"
+  work_buf_additional_days: "float(0,30)?"
 image: "ghcr.io/hectorespert/addon-boinc"
 # `apparmor` defaults to true, and Supervisor loads apparmor.txt as the profile when the file is
 # present, so neither is declared here -- the add-on linter rejects redeclaring a default.

--- a/boinc/operator/global_prefs_override.py
+++ b/boinc/operator/global_prefs_override.py
@@ -6,13 +6,16 @@ import xml.etree.ElementTree as ElementTree
 ROOT_ELEMENT = 'global_preferences'
 
 # The preferences this operator owns, in the order they are written: the computing schedule pair,
-# then the in-use CPU limits, then their not-in-use ("niu_") counterparts -- the same order BOINC
-# Manager uses in its own preferences dialog. Everything else in global_prefs_override.xml belongs
-# to whoever put it there (boinctui, a remote BOINC Manager) and is preserved untouched.
+# then the in-use CPU limits, then their not-in-use ("niu_") counterparts, then the disk limits and
+# the work buffer -- the same order BOINC Manager uses in its own preferences dialog. Everything
+# else in global_prefs_override.xml belongs to whoever put it there (boinctui, a remote BOINC
+# Manager) and is preserved untouched.
 MANAGED_PREFERENCES = (
     'start_hour', 'end_hour',
     'max_ncpus_pct', 'cpu_usage_limit',
     'niu_max_ncpus_pct', 'niu_cpu_usage_limit',
+    'disk_max_used_gb', 'disk_max_used_pct', 'disk_min_free_gb',
+    'work_buf_min_days', 'work_buf_additional_days',
 )
 
 # What the operator wrote on its last run. BOINC cannot record this for us: the client writes the
@@ -71,6 +74,36 @@ def build_managed_preferences(data: dict) -> dict:
     max_cpu_usage_idle = data.get('cpu_usage_limit_idle')
     if max_cpu_usage_idle is not None:
         preferences['niu_cpu_usage_limit'] = max_cpu_usage_idle
+
+    # The three disk limits are independent and the client applies the *least* of them
+    # (CLIENT_STATE::allowed_disk_usage, client/cs_prefs.cpp), so setting one does not disable
+    # another -- which is why all three are exposed rather than a chosen pair. Zero is meaningful
+    # for the first two and means "no limit": the client skips a limit whose value is falsy, so
+    # writing 0 is not the same as leaving the option unset, which removes the tag entirely and
+    # restores BOINC's own default.
+    disk_max_used_gb = data.get('disk_max_used_gb')
+    if disk_max_used_gb is not None:
+        preferences['disk_max_used_gb'] = disk_max_used_gb
+
+    disk_max_used_pct = data.get('disk_max_used_pct')
+    if disk_max_used_pct is not None:
+        preferences['disk_max_used_pct'] = disk_max_used_pct
+
+    disk_min_free_gb = data.get('disk_min_free_gb')
+    if disk_min_free_gb is not None:
+        preferences['disk_min_free_gb'] = disk_min_free_gb
+
+    # How much work to keep queued. These two add up: the client asks for work until it holds
+    # work_buf_min_days, and tops up to work_buf_min_days + work_buf_additional_days when it talks
+    # to a project anyway. Both are clamped at zero by the client (GLOBAL_PREFS::parse), and the
+    # schema already refuses a negative, so nothing is validated here.
+    work_buf_min_days = data.get('work_buf_min_days')
+    if work_buf_min_days is not None:
+        preferences['work_buf_min_days'] = work_buf_min_days
+
+    work_buf_additional_days = data.get('work_buf_additional_days')
+    if work_buf_additional_days is not None:
+        preferences['work_buf_additional_days'] = work_buf_additional_days
 
     return preferences
 

--- a/boinc/operator/test/test_global_prefs_override.py
+++ b/boinc/operator/test/test_global_prefs_override.py
@@ -101,6 +101,66 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
         self.assertEqual(self.read_preferences(self.global_prefs_override),
                          '<global_preferences>\n  <niu_max_ncpus_pct>10</niu_max_ncpus_pct>\n  <niu_cpu_usage_limit>20.0</niu_cpu_usage_limit>\n</global_preferences>')
 
+    def test_should_create_global_prefs_override_with_disk_configurations(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {
+            'disk_max_used_gb': 20.0,
+            'disk_max_used_pct': 50.0,
+            'disk_min_free_gb': 5.0
+        })
+
+        self.assertFalse(os.path.islink(self.global_prefs_override))
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n'
+                         '  <disk_max_used_gb>20.0</disk_max_used_gb>\n'
+                         '  <disk_max_used_pct>50.0</disk_max_used_pct>\n'
+                         '  <disk_min_free_gb>5.0</disk_min_free_gb>\n'
+                         '</global_preferences>')
+
+    def test_should_write_a_zero_disk_limit_because_boinc_reads_it_as_no_limit(self):
+        # Zero is not the same as unset here: the client skips a falsy limit
+        # (CLIENT_STATE::allowed_disk_usage), so writing 0 lifts the cap, while leaving the option
+        # out removes the tag and restores BOINC's own default.
+        link_global_prefs_override(self.data_dir, self.config_dir, {'disk_max_used_pct': 0})
+
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n  <disk_max_used_pct>0</disk_max_used_pct>\n</global_preferences>')
+        self.assertEqual(self.read_managed_state(), {'disk_max_used_pct': 0})
+
+    def test_should_create_global_prefs_override_with_work_buffer_configurations(self):
+        link_global_prefs_override(self.data_dir, self.config_dir, {
+            'work_buf_min_days': 0.5,
+            'work_buf_additional_days': 1.5
+        })
+
+        self.assertFalse(os.path.islink(self.global_prefs_override))
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n'
+                         '  <work_buf_min_days>0.5</work_buf_min_days>\n'
+                         '  <work_buf_additional_days>1.5</work_buf_additional_days>\n'
+                         '</global_preferences>')
+
+    def test_should_remove_a_disk_limit_it_wrote_when_its_option_is_gone(self):
+        self.write_managed_state({'disk_min_free_gb': 5.0})
+        self.write_preferences(self.global_prefs_override,
+                               '<global_preferences>\n  <disk_min_free_gb>5.0</disk_min_free_gb>\n</global_preferences>')
+
+        link_global_prefs_override(self.data_dir, self.config_dir, {})
+
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n</global_preferences>')
+        self.assertEqual(self.read_managed_state(), {})
+
+    def test_should_keep_a_disk_limit_set_from_boinctui(self):
+        # Same key, opposite outcome to the test above, and the managed-state file is the only
+        # thing that tells them apart: nothing wrote this one, so it is not the operator's to remove.
+        self.write_preferences(self.global_prefs_override,
+                               '<global_preferences>\n  <disk_min_free_gb>5.0</disk_min_free_gb>\n</global_preferences>')
+
+        link_global_prefs_override(self.data_dir, self.config_dir, {})
+
+        self.assertEqual(self.read_preferences(self.global_prefs_override),
+                         '<global_preferences>\n  <disk_min_free_gb>5.0</disk_min_free_gb>\n</global_preferences>')
+
     def test_should_write_all_managed_preferences_in_boinc_manager_order(self):
         link_global_prefs_override(self.data_dir, self.config_dir, {
             'start_hour': '00:35',
@@ -108,11 +168,16 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
             'max_ncpus': 50,
             'cpu_usage_limit': 75.0,
             'max_ncpus_idle': 10,
-            'cpu_usage_limit_idle': 20.0
+            'cpu_usage_limit_idle': 20.0,
+            'disk_max_used_gb': 20.0,
+            'disk_max_used_pct': 50.0,
+            'disk_min_free_gb': 5.0,
+            'work_buf_min_days': 0.5,
+            'work_buf_additional_days': 1.5
         })
 
-        # In-use pair, then not-in-use pair, the same order BOINC Manager's own preferences dialog
-        # presents them in.
+        # In-use pair, then not-in-use pair, then disk and the work buffer, the same order BOINC
+        # Manager's own preferences dialog presents them in.
         self.assertEqual(self.read_preferences(self.global_prefs_override),
                          '<global_preferences>\n'
                          '  <start_hour>0.35</start_hour>\n'
@@ -121,6 +186,11 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
                          '  <cpu_usage_limit>75.0</cpu_usage_limit>\n'
                          '  <niu_max_ncpus_pct>10</niu_max_ncpus_pct>\n'
                          '  <niu_cpu_usage_limit>20.0</niu_cpu_usage_limit>\n'
+                         '  <disk_max_used_gb>20.0</disk_max_used_gb>\n'
+                         '  <disk_max_used_pct>50.0</disk_max_used_pct>\n'
+                         '  <disk_min_free_gb>5.0</disk_min_free_gb>\n'
+                         '  <work_buf_min_days>0.5</work_buf_min_days>\n'
+                         '  <work_buf_additional_days>1.5</work_buf_additional_days>\n'
                          '</global_preferences>')
 
     def test_should_migrate_a_stale_niu_preference_the_operator_wrote_to_the_in_use_key(self):
@@ -197,33 +267,37 @@ class GlobalPreferencesOverrideTestCase(unittest.TestCase):
         self.assertEqual(self.read_preferences(self.global_prefs_override),
                          '<global_preferences>\n</global_preferences>')
 
+    # ram_max_used_busy_pct stands in for "a preference the operator does not own" in the three
+    # tests below. It used to be disk_max_used_gb, which stopped being unmanaged when the disk
+    # limits were added -- leaving the tests passing while no longer testing what they are named
+    # for. Pick another unmanaged preference if this one is ever exposed as an option too.
     def test_should_keep_preferences_set_outside_the_add_on(self):
         self.write_preferences(self.global_prefs_override,
-                               '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
+                               '<global_preferences>\n  <ram_max_used_busy_pct>50</ram_max_used_busy_pct>\n</global_preferences>')
 
         link_global_prefs_override(self.data_dir, self.config_dir, {'max_ncpus': 50})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n  <max_ncpus_pct>50</max_ncpus_pct>\n</global_preferences>')
+                         '<global_preferences>\n  <ram_max_used_busy_pct>50</ram_max_used_busy_pct>\n  <max_ncpus_pct>50</max_ncpus_pct>\n</global_preferences>')
 
     def test_should_update_a_managed_preference_in_place(self):
         self.write_preferences(self.global_prefs_override,
-                               '<global_preferences>\n  <start_hour>22.0</start_hour>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
+                               '<global_preferences>\n  <start_hour>22.0</start_hour>\n  <ram_max_used_busy_pct>50</ram_max_used_busy_pct>\n</global_preferences>')
 
         link_global_prefs_override(self.data_dir, self.config_dir, {'start_hour': '00:35', 'end_hour': '08:59'})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <start_hour>0.35</start_hour>\n  <disk_max_used_gb>100</disk_max_used_gb>\n  <end_hour>8.59</end_hour>\n</global_preferences>')
+                         '<global_preferences>\n  <start_hour>0.35</start_hour>\n  <ram_max_used_busy_pct>50</ram_max_used_busy_pct>\n  <end_hour>8.59</end_hour>\n</global_preferences>')
 
     def test_should_remove_a_managed_preference_it_wrote_when_its_option_is_gone(self):
         self.write_managed_state({'start_hour': 22.0})
         self.write_preferences(self.global_prefs_override,
-                               '<global_preferences>\n  <start_hour>22.0</start_hour>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
+                               '<global_preferences>\n  <start_hour>22.0</start_hour>\n  <ram_max_used_busy_pct>50</ram_max_used_busy_pct>\n</global_preferences>')
 
         link_global_prefs_override(self.data_dir, self.config_dir, {})
 
         self.assertEqual(self.read_preferences(self.global_prefs_override),
-                         '<global_preferences>\n  <disk_max_used_gb>100</disk_max_used_gb>\n</global_preferences>')
+                         '<global_preferences>\n  <ram_max_used_busy_pct>50</ram_max_used_busy_pct>\n</global_preferences>')
         self.assertEqual(self.read_managed_state(), {})
 
     def test_should_keep_a_managed_preference_it_never_wrote(self):

--- a/boinc/translations/en.yaml
+++ b/boinc/translations/en.yaml
@@ -38,5 +38,20 @@ configuration:
   cpu_usage_limit_idle:
     name: Max CPU Usage Percentage (Not In Use)
     description: "Maximum percentage of time each CPU can be used while the computer is not in use, instead of Max CPU Usage Percentage"
+  disk_max_used_gb:
+    name: Maximum Disk Space (GB)
+    description: "Never use more than this many gigabytes for science data. Leave empty for no limit of this kind; whichever of the three disk limits is strictest wins"
+  disk_max_used_pct:
+    name: Maximum Disk Space (Percentage)
+    description: "Never use more than this percentage of the total disk. Leave empty to keep BOINC's default of 90%; whichever of the three disk limits is strictest wins"
+  disk_min_free_gb:
+    name: Minimum Free Disk Space (GB)
+    description: "Always leave at least this many gigabytes free. The safest of the three limits on a small machine, because it protects the disk rather than capping science data"
+  work_buf_min_days:
+    name: Minimum Work Buffer (Days)
+    description: "How many days of work to keep queued, so computing continues while the internet is down. Larger buffers make backups bigger and risk missing deadlines"
+  work_buf_additional_days:
+    name: Additional Work Buffer (Days)
+    description: "Extra days of work to fetch on top of the minimum, so BOINC asks for work less often. Set both to zero to download tasks only as they are needed"
 network:
   31416/tcp: BOINC client GUI RPC port (default 31416)

--- a/boinc/translations/es.yaml
+++ b/boinc/translations/es.yaml
@@ -38,5 +38,20 @@ configuration:
   cpu_usage_limit_idle:
     name: Porcentaje Máximo de Uso de CPU (Sin Usar)
     description: "Porcentaje máximo de tiempo que puede usarse cada CPU mientras el equipo no está en uso, en lugar de Porcentaje Máximo de Uso de CPU"
+  disk_max_used_gb:
+    name: Espacio Máximo en Disco (GB)
+    description: "No usar nunca más de estos gigabytes para datos científicos. Vacío deja sin poner este límite; de los tres límites se aplica el más estricto"
+  disk_max_used_pct:
+    name: Espacio Máximo en Disco (Porcentaje)
+    description: "No usar nunca más de este porcentaje del disco. Vacío mantiene el valor por defecto de BOINC, el 90%; de los tres límites se aplica el más estricto"
+  disk_min_free_gb:
+    name: Espacio Libre Mínimo en Disco (GB)
+    description: "Dejar siempre libres al menos estos gigabytes. El más seguro de los tres en un equipo pequeño: protege el disco en vez de limitar los datos"
+  work_buf_min_days:
+    name: Reserva Mínima de Trabajo (Días)
+    description: "Días de trabajo a mantener en cola, para seguir computando sin internet. Una reserva grande agranda las copias de seguridad y arriesga incumplir plazos"
+  work_buf_additional_days:
+    name: Reserva Adicional de Trabajo (Días)
+    description: "Días de trabajo extra sobre el mínimo, para que BOINC pida trabajo menos a menudo. Pon ambos a cero para descargar tareas solo según hagan falta"
 network:
   31416/tcp: Puerto GUI RPC del cliente BOINC (por defecto 31416)


### PR DESCRIPTION
Cierra dos huecos del backlog (`work_buf_*` y `disk_max_used_*`) y arrastra consigo la mitad `boinc` del PR #147, que estaba aparcado esperando una release real. **`boinc` 3.12.0.**

## Las cinco opciones

`disk_max_used_gb`, `disk_max_used_pct`, `disk_min_free_gb`, `work_buf_min_days`, `work_buf_additional_days`.

Cinco entradas en `MANAGED_PREFERENCES` y cinco bloques en `build_managed_preferences`. El merge a tres bandas de 3.8.1 se encarga del resto sin tocarlo: escribir cuando la opción está puesta, retirar cuando desaparece **y la escribió el operador**, y no tocar nunca una preferencia que puso otro.

## Tres decisiones que cambiaron respecto al backlog

**Van los tres límites de disco, no la pareja que proponía el TODO.** Son independientes y el cliente aplica **el más estricto de los tres** (`CLIENT_STATE::allowed_disk_usage`, `client/cs_prefs.cpp`), así que exponer dos habría hecho que la ausencia del tercero pareciera un límite inexistente. Además `disk_min_free_gb` es el más útil en un host pequeño: protege el disco en lugar de limitar los datos científicos, que es justo el miedo del usuario de Home Assistant.

**El cero significa algo, y no es lo mismo que dejar la opción vacía.** El cliente se salta un límite cuyo valor es falsy, así que `0` es *sin límite*, mientras que quitar la opción borra la etiqueta y devuelve el valor por defecto de BOINC. Los dos caminos tienen test. La documentación lo dice explícitamente, porque "0 = ilimitado" se lee como "0 = no permitir nada" para cualquiera que no haya leído el código.

**Rango sin techo para los dos límites en GB.** `float(0,)` es válido — `RE_SCHEMA_ELEMENT` hace opcionales ambos extremos — y un host puede tener cualquier cantidad de almacenamiento, así que un tope inventado solo podría estar mal.

## Verificado contra un cliente real, no solo en tests

Que el fichero se parsee no prueba nada: **el cliente descarta en silencio las etiquetas que no conoce.** Y `boinccmd` no sabe volcar las preferencias efectivas, así que la comprobación fue por GUI RPC con `get_global_prefs_working`, que es la respuesta que lee BOINC Manager:

```
disk_max_used_gb           = 20.000000
disk_max_used_pct          = 50.000000
disk_min_free_gb           =  5.000000
work_buf_min_days          =  0.500000
work_buf_additional_days   =  1.500000
```

Y el otro lado del merge — quitar cuatro de las cinco opciones y reiniciar:

```
disk_max_used_gb           = 0.000000     <- default de BOINC
disk_max_used_pct          = 90.000000    <- default de BOINC
disk_min_free_gb           = 5.000000     <- su opción sigue puesta
work_buf_min_days          = 0.100000     <- default de BOINC
work_buf_additional_days   = 0.500000     <- default de BOINC
```

Son exactamente los valores que declara `defaults()` en `lib/prefs.cpp`.

## Un test que había dejado de probar lo que decía su nombre

Tres tests usaban `disk_max_used_gb` como suplente de "una preferencia puesta fuera del add-on" — y este cambio la convierte en gestionada. Seguían pasando mientras afirmaban otra cosa. Cambiados a `ram_max_used_busy_pct`, con un comentario que nombra la trampa para quien exponga esa opción algún día.

## Lo demás

- `DOCS.md`: dos secciones nuevas, un ejemplo de configuración para disco/backups pequeños, y **la nota de cierre actualizada** — decía "esas seis opciones" y ponía los límites de disco y el buffer como ejemplos de lo que el add-on *no* toca, que es justo lo que deja de ser cierto. Añade también qué le pasa a quien ya tenía esos valores puestos desde boinctui.
- `translations/` en los dos idiomas.
- `TODO.md`: cierra los dos huecos, y de paso mueve a *Resolved* los ítems de `init: false` y del `boinc` hardcodeado en `build-addons.yaml`, cuyos cierres se habían quedado atrapados en el #147 sin querer.

## Comprobado

- `python -m unittest discover` en `boinc/operator`: **108 tests OK** (5 nuevos).
- Smoke test estilo CI (`--exit-immediately`): exit 0.
- `yamllint` y `hadolint`: limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka