### PR TITLE
docs(boinctui): record why init: false is right here

### DIFF
--- a/boinctui/config.yaml
+++ b/boinctui/config.yaml
@@ -6,6 +6,11 @@ url: "https://github.com/hectorespert/boinc-addons/tree/main/boinctui"
 arch:
   - aarch64
   - amd64
+# Not for the documented reason ("the image has its own init system") — this one has none. ttyd is
+# PID 1 and reaps its own children: run.sh execs into it, and each session is
+# `bash -c "... exec boinctui"`, so the session process is a *direct* child of ttyd with no shell
+# left in between. Measured 2026-08-16 — ten sessions opened and closed left no zombie — so Docker's
+# init would add a process with nothing to collect.
 init: false
 ingress: true
 ingress_port: 7681


### PR DESCRIPTION
> [!IMPORTANT]
> **Aparcado a propósito. No mergear solo: CI fallará.**
>
> Solo cambia un comentario, así que no lleva bump de versión — pero `config.yaml` está en `monitored_files`, y `check-version` en modo estricto rechaza el add-on porque su tag ya existe (`.github/workflows/check-version.yaml:54`). En el PR el check es informativo y pasa; el fallo llega al mergear a `main`.
>
> **Para desaparcarlo:** rebasar sobre la rama que traiga la próxima release real de `boinctui`, subir su versión, escribir la entrada de `CHANGELOG.md` sobre **ese** cambio (no sobre este comentario), y quitar el borrador.

Uno de los tres trozos en que se partió #147. La documentación de HA justifica `init: false` solo cuando la imagen trae su propio init (s6-overlay), y esta no lo trae: parte de `debian:13.5-slim` pelado y el `ENTRYPOINT` es directamente el proceso de trabajo. El flag lleva tiempo pareciendo injustificado a quien lo lee, y no lo está — la razón real nunca se escribió al lado.

La razón, y la medición que la respalda, están en la entrada de *Discarded after investigation* de `TODO.md` que llega en #148, junto con el comentario equivalente de `boinc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rSyRhBJFxHtcCnkzKmQka